### PR TITLE
[Feature] 프로필 상세 및 편집 화면 구현

### DIFF
--- a/SwypApp2nd/Sources/ViewModels/My/MyViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/My/MyViewModel.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import UserNotifications
+import CoreData
+
+class MyViewModel: ObservableObject {
+    // get 연결 계정 info
+    // 알림 설정 on /off
+    // 서비스 정보
+    
+}

--- a/SwypApp2nd/Sources/ViewModels/My/ProfileEditViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/My/ProfileEditViewModel.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import UserNotifications
+import CoreData
+
+class ProfileEditViewModel: ObservableObject {
+    
+    private let personRepo = PersonRepository()
+    private let reminderRepo = ReminderRepository()
+    
+    @Published var people: [PersonEntity] = []
+    @Published var reminders: [ReminderEntity] = []
+    
+    func addNewPerson(name: String, relationship: String, birthday: Date?, anniversary: Date?, reminderInterval: String, memo: String?) {
+        let newPerson = personRepo.addPerson(name: name, relationship: relationship, birthday: birthday, anniversary: anniversary, reminderInterval: reminderInterval, memo:memo)
+        reminderRepo.addReminder(for: newPerson)
+    }
+    
+}

--- a/SwypApp2nd/Sources/Views/My/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/My/ProfileDetailView.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+struct ProfileDetailView: View {
+    var person: PersonEntity
+    @State private var selectedTab: Tab = .profile
+
+    enum Tab {
+        case profile, records
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProfileHeader(person: person)
+            ActionButtonRow()
+            ProfileTabBar(selected: $selectedTab)
+            
+            if selectedTab == .profile {
+                ProfileInfoSection(person: person)
+            } else {
+                Text("기록 탭")
+            }
+            
+            Spacer()
+            
+            ConfirmButton(title: "챙김 기록하기") {
+                // TODO
+            }
+        }
+        .padding()
+    }
+}
+
+private struct ProfileHeader: View {
+    var person: PersonEntity
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: "person.crop.circle.fill")
+                    .resizable()
+                    .frame(width: 80, height: 80)
+                    .foregroundColor(.gray.opacity(0.3))
+
+                Text("😐")
+                    .font(.title2)
+                    .offset(x: 0, y: -5)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                
+                Text(person.name)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                
+                Text("데이터 연동 필요")
+                    .font(.caption)
+                    .foregroundColor(.blue)
+            }
+        }
+    }
+}
+
+private struct ActionButtonRow: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            ActionButton(title: "전화걸기", systemImage: "phone")
+            ActionButton(title: "문자하기", systemImage: "ellipsis.message")
+        }
+    }
+}
+
+private struct ActionButton: View {
+    var title: String
+    var systemImage: String
+
+    var body: some View {
+        VStack {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .padding(12)
+                .background(Color.gray.opacity(0.1))
+                .clipShape(Circle())
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.gray)
+        }
+    }
+}
+
+private struct ProfileTabBar: View {
+    @Binding var selected: ProfileDetailView.Tab
+
+    var body: some View {
+        HStack {
+            TabButton(title: "프로필", selected: $selected, tab: .profile)
+            TabButton(title: "기록", selected: $selected, tab: .records)
+        }
+        .padding(6)
+        .background(Color.gray.opacity(0.1))
+        .clipShape(Capsule())
+    }
+}
+
+private struct TabButton: View {
+    var title: String
+    @Binding var selected: ProfileDetailView.Tab
+    var tab: ProfileDetailView.Tab
+
+    var body: some View {
+        Button(action: {
+            selected = tab
+        }) {
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(selected == tab ? .white : .gray)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 20)
+                .background(selected == tab ? Color.blue : Color.clear)
+                .clipShape(Capsule())
+        }
+    }
+}
+
+private struct ProfileInfoSection: View {
+    var person: PersonEntity
+
+    var body: some View {
+        VStack(spacing: 12) {
+            InfoRow(label: "관계", value: person.relationship)
+            InfoRow(label: "연락 주기", value: person.reminderInterval)
+            InfoRow(label: "생일", value: formatDate(person.birthday))
+            InfoRow(label: "기념일", value: "결혼기념일 (\(formatDate(person.anniversary)))")
+            InfoRow(label: "메모", value: person.memo ?? "-")
+        }
+    }
+
+    private func formatDate(_ date: Date?) -> String {
+        guard let date = date else { return "-" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter.string(from: date)
+    }
+}
+
+private struct InfoRow: View {
+    var label: String
+    var value: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(.gray)
+            Spacer()
+            Text(value)
+                .font(.subheadline)
+        }
+        .padding()
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.gray.opacity(0.2)))
+    }
+}
+
+private struct ConfirmButton: View {
+    var title: String
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.blue)
+                .cornerRadius(12)
+        }
+    }
+}
+struct ProfileDetail_Preview: PreviewProvider {
+    static var previews: some View {
+        // Replace with valid PersonEntity for preview
+        let context = CoreDataStack.shared.context
+        let mockPerson = PersonEntity.mockPerson(context: context)
+        
+        ProfileDetailView(person: mockPerson)
+    }
+}
+
+
+

--- a/SwypApp2nd/Sources/Views/My/ProfileEditView.swift
+++ b/SwypApp2nd/Sources/Views/My/ProfileEditView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import CoreData
+
+struct ProfileEditView: View {
+    
+    @StateObject var profileEditViewModel = ProfileEditViewModel()
+    @Environment(\.presentationMode) var presentationMode
+    
+    @State private var name: String = ""
+    @State private var relationship: String = "친구"
+    @State private var contactFrequency: String = "매주"
+    @State private var birthday: Date? = nil  // Optional Date for birthday
+    @State private var anniversaries: [(label: String, date: Date?)] = [("", nil)]
+    @State private var memo: String = ""
+    
+    let contactFrequencies = ["매일", "매주", "2주", "매달", "매분기", "6개월","매년"]
+    
+    var body: some View {
+        VStack {
+            Form {
+                Section(header: Text("이름")) {
+                    TextField("이름 입력", text: $name)
+                }
+                
+                Section(header: Text("관계")) {
+                    Picker("관계", selection: $relationship) {
+                        Text("친구").tag("친구")
+                        Text("가족").tag("가족")
+                        Text("지인").tag("지인")
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                }
+                
+                Section(header: Text("연락 주기")) {
+                    Picker("연락 주기", selection: $contactFrequency) {
+                        ForEach(contactFrequencies, id: \.self) {
+                            Text($0)
+                        }
+                    }
+                    .pickerStyle(MenuPickerStyle())
+                }
+                
+                Section(header: Text("생일")) {
+                    // Use nil-coalescing operator to provide a default value if birthday is nil
+                    DatePicker("날짜 선택", selection: Binding(
+                        get: { birthday ?? Date() },
+                        set: { birthday = $0 }
+                    ), displayedComponents: .date)
+                }
+                
+                Section(header: Text("기념일")) {
+                    ForEach(anniversaries.indices, id: \.self) { index in
+                        HStack {
+                            TextField("레이블", text: $anniversaries[index].label)
+                            // Use nil-coalescing operator to provide a default value if anniversaries[index].date is nil
+                            DatePicker("날짜 선택", selection: Binding(
+                                get: { anniversaries[index].date ?? Date() },
+                                set: { anniversaries[index].date = $0 }
+                            ), displayedComponents: .date)
+                        }
+                    }
+                    Button(action: {
+                        // Append a new anniversary with default date as Date()
+                        anniversaries.append(("", nil))
+                    }) {
+                        Label("일정 추가하기", systemImage: "plus")
+                    }
+                }
+                
+                Section(header: Text("메모")) {
+                    TextEditor(text: $memo)
+                        .frame(height: 100)
+                }
+            }
+            
+            Button(action: {
+                profileEditViewModel.addNewPerson(name: name, relationship: relationship, birthday: birthday, anniversary: anniversaries.first?.date, reminderInterval: contactFrequency, memo: memo)
+                presentationMode.wrappedValue.dismiss()
+            }) {
+                Text("완료")
+                    .bold()
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+            .padding()
+        }
+    }
+}
+
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        // Replace with valid PersonEntity for preview
+        ProfileEditView()
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 사용자 정보 바인딩을 확인을 위한 간단한 유저 프로필 뷰/뷰모델 

## 📄 작업 내용 상세 설명
-  프로필 상세: ProfileDetailView.swift, 프로필 편집 ProfileEditView.swift 화면 생성했습니다
- MVVM 패턴 적용: MyViewModel.swift, ProfileEditViewModel.swift 생성했습니다
- 상세 뷰 레이아웃 완성 및 사용자 정보 바인딩 적용했습니다

### 🎯 작업 목적
-  알림을 등록했을 때 그 알림을 클릭하면 챙길 사람의 프로필도 이동 해야 해서 확인을 위한 뷰를 만들었습니다

### 🛠️ 주요 변경 사항
- 파일명 변경/ 추가: MyViewModel.swift
- 파일명 변경/ 추가: ProfileEditViewModel.swift
- 파일명 변경/ 추가: ProfileDetailView.swift
- 파일명 변경/ 추가: ProfileEditlView.swift

### 📸 스크린샷 (필요시 추가)
<img width="357" alt="Screenshot 2025-04-06 at 8 21 24 PM" src="https://github.com/user-attachments/assets/fce57fa4-6079-47a9-aad8-b5b3d0404e37" />

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- ProfileEditView.swift 는 알림 등록 화면이라 나중에 파일 이름 수정이 필요할 것 같습니다

### ✅ 참고 이슈 및 관련 작업
.