### PR TITLE
[Feature] 프로필 상세 정보 수정 뷰 UI 수정: birthday, anniversary wheel picker, main 글자수 indicator 추가

### DIFF
--- a/SwypApp2nd/Sources/Views/My/ProfileEditView.swift
+++ b/SwypApp2nd/Sources/Views/My/ProfileEditView.swift
@@ -1,27 +1,41 @@
-import SwiftUI
 import CoreData
+import SwiftUI
+
+struct Anniversary: Identifiable {
+    let id = UUID()
+    var label: String
+    var date: Date?
+}
 
 struct ProfileEditView: View {
-    
     @StateObject var profileEditViewModel = ProfileEditViewModel()
+    @StateObject var notificationViewModel = NotificationViewModel()
     @Environment(\.presentationMode) var presentationMode
-    
+
     @State private var name: String = ""
     @State private var relationship: String = "친구"
     @State private var contactFrequency: String = "매주"
-    @State private var birthday: Date? = nil  // Optional Date for birthday
-    @State private var anniversaries: [(label: String, date: Date?)] = [("", nil)]
+    @State private var birthday: Date? = nil
+    @State private var anniversaries: [Anniversary] = []
     @State private var memo: String = ""
-    
-    let contactFrequencies = ["매일", "매주", "2주", "매달", "매분기", "6개월","매년"]
-    
+
+    let contactFrequencies = ["매일", "매주", "2주", "매달", "매분기", "6개월", "매년"]
+
     var body: some View {
         VStack {
             Form {
                 Section(header: Text("이름")) {
-                    TextField("이름 입력", text: $name)
+                    VStack(alignment: .leading, spacing: 4) {
+                        TextField("20자 내로 이름을 입력해주세요", text: $name)
+                            .autocorrectionDisabled(true)
+                            .textInputAutocapitalization(.never)
+                            .onChange(of: name) {
+                                if name.count > 20 {
+                                    name = String(name.prefix(20))
+                                }
+                            }
+                    }
                 }
-                
                 Section(header: Text("관계")) {
                     Picker("관계", selection: $relationship) {
                         Text("친구").tag("친구")
@@ -30,7 +44,6 @@ struct ProfileEditView: View {
                     }
                     .pickerStyle(SegmentedPickerStyle())
                 }
-                
                 Section(header: Text("연락 주기")) {
                     Picker("연락 주기", selection: $contactFrequency) {
                         ForEach(contactFrequencies, id: \.self) {
@@ -39,42 +52,63 @@ struct ProfileEditView: View {
                     }
                     .pickerStyle(MenuPickerStyle())
                 }
-                
-                Section(header: Text("생일")) {
-                    // Use nil-coalescing operator to provide a default value if birthday is nil
-                    DatePicker("날짜 선택", selection: Binding(
-                        get: { birthday ?? Date() },
-                        set: { birthday = $0 }
-                    ), displayedComponents: .date)
-                }
-                
+
+                WheelDatePicker(title: "생일", showEmptyYear: true, limitToPast: true, date: $birthday)
+
                 Section(header: Text("기념일")) {
-                    ForEach(anniversaries.indices, id: \.self) { index in
+                    ForEach($anniversaries) { $anniversary in
+                        // TODO: Add delete
+                        // TODO: Design enhancement - HStack might be better
+                        VStack(alignment: .leading, spacing: 8) {
+                            TextField("기념일 이름", text: $anniversary.label)
+                                .autocorrectionDisabled(true)
+                                .textInputAutocapitalization(.never)
+                            WheelDatePicker(title: "", showEmptyYear: true, limitToPast: false, date: $anniversary.date)
+                        }
+                        .padding(.vertical, 4)
+                    }
+
+                    Button("일정 추가") {
+                        anniversaries.append(Anniversary(label: "", date: nil))
+                    }
+                }
+
+                Section(header: Text("메모")) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ZStack(alignment: .topLeading) {
+                            if memo.isEmpty {
+                                Text("""
+                                꼭 기억해야 할 내용을 기록해보세요.
+                                예) 날생선 X, 작년 생일에 키링 선물함 등
+                                """)
+                                .foregroundColor(.gray)
+                                .padding(8)
+                            }
+
+                            TextEditor(text: $memo)
+                                .onChange(of: memo) {
+                                    if memo.count > 100 {
+                                        memo = String(memo.prefix(100))
+                                    }
+                                }
+                                .autocorrectionDisabled(true)
+                                .textInputAutocapitalization(.never)
+                                .frame(height: 100)
+                        }
+
                         HStack {
-                            TextField("레이블", text: $anniversaries[index].label)
-                            // Use nil-coalescing operator to provide a default value if anniversaries[index].date is nil
-                            DatePicker("날짜 선택", selection: Binding(
-                                get: { anniversaries[index].date ?? Date() },
-                                set: { anniversaries[index].date = $0 }
-                            ), displayedComponents: .date)
+                            Spacer()
+                            Text("\(memo.count)/100")
+                                .font(.caption)
+                                .foregroundColor(.gray)
                         }
                     }
-                    Button(action: {
-                        // Append a new anniversary with default date as Date()
-                        anniversaries.append(("", nil))
-                    }) {
-                        Label("일정 추가하기", systemImage: "plus")
-                    }
-                }
-                
-                Section(header: Text("메모")) {
-                    TextEditor(text: $memo)
-                        .frame(height: 100)
                 }
             }
-            
+
             Button(action: {
-                profileEditViewModel.addNewPerson(name: name, relationship: relationship, birthday: birthday, anniversary: anniversaries.first?.date, reminderInterval: contactFrequency, memo: memo)
+                let person = profileEditViewModel.addNewPerson(name: name, relationship: relationship, birthday: birthday, anniversary: anniversaries.first?.date, reminderInterval: contactFrequency, memo: memo) // TODO 이거 context save로 바꿀 수 있다고?
+                notificationViewModel.scheduleAllReminders(for: person)
                 presentationMode.wrappedValue.dismiss()
             }) {
                 Text("완료")
@@ -87,6 +121,55 @@ struct ProfileEditView: View {
             }
             .padding()
         }
+    }
+}
+
+struct WheelDatePicker: View {
+    let title: String
+    let showEmptyYear: Bool
+    let limitToPast: Bool
+    @Binding var date: Date?
+    @State private var isPickerVisible = false
+
+    var body: some View {
+        Section(header: Text(title)) {
+            Button {
+                isPickerVisible.toggle()
+            } label: {
+                HStack {
+//                    Text("날짜 선택")
+//                        .foregroundColor(.primary)
+//                    Spacer()
+                    Text(date != nil ? formattedDate(date!) : "선택 안함")
+                        .foregroundColor(date != nil ? .primary : .gray)
+                }
+            }
+
+            let maxDate = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+            let dateRange = limitToPast ? Date.distantPast...maxDate : Date.distantPast...Date.distantFuture
+
+            if isPickerVisible {
+                // TODO: limit date range if needed (bday should only have date options prior to today)
+                DatePicker(
+                    "",
+                    selection: Binding(
+                        get: { date ?? Date() },
+                        set: { date = $0 }
+                    ),
+                    in: dateRange,
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.wheel)
+                .labelsHidden()
+            }
+        }
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일"
+        return formatter.string(from: date)
     }
 }
 


### PR DESCRIPTION
## ✨ 변경 사항 요약
- ProfileEditView.swift  wheel picker랑 글자수, Place Holder 등등 베이직 ui 업데이트 입니다

## 📄 작업 내용 상세 설명
- Wheel picker
- memo 글자수 체크
- Textfield placeholder
- 추가 기념일

### 🎯 작업 목적
-  디자인/기능 명세서에 있던 대로 기본적인 UI 만 추가하였습니다. 종원님이 더 디벨롭 해주시면 될 것 같아요

### 🛠️ 주요 변경 사항
-  생일 wheel picker (미래 선택 불가)
- 기념일 wheel picker (미래 선택 가능)

### 📸 스크린샷 (필요시 추가)
<img width="249" alt="Screenshot 2025-04-13 at 1 06 21 AM" src="https://github.com/user-attachments/assets/9d9ac352-1d73-4aa2-a430-f803e815059e" />

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- notificationViewModel.scheduleAllReminders(for: person)이 없다고 뜰 텐데 현재 pr에 포함이 되어 있어서 뜨는 에러이니 주석 처리 하셔도 무방합니다.
- 추가 기념일 삭제는 아직 없습니다..^^
-  날짜들 모두 디폴트 값이 미선택이여서 만약 오늘을 선택하고 싶으면 다른 날짜를 선택한 후에 다시 돌아가야한다는 번거로움이 있습니다.

### ✅ 참고 이슈 및 관련 작업
.