### PR TITLE
[Feature] 내 프로필 뷰 및 탈퇴 뷰 추가

### DIFF
--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+struct MyProfileView: View {
+    @State private var showWithdrawalSheet = false
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                UserProfileSectionView()
+
+                AccountSettingSectionView()
+
+                ServiceInfoSectionView()
+
+                Spacer()
+
+                WithdrawalButtonView {
+                    showWithdrawalSheet = true
+                }
+            }
+            .fullScreenCover(isPresented: $showWithdrawalSheet) {
+                WithdrawalView()
+            }
+            .padding(.horizontal)
+            .navigationBarTitle("MY", displayMode: .inline)
+        }
+    }
+}
+
+
+struct UserProfileSectionView: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            Circle()
+                .fill(Color.gray.opacity(0.3))
+                .frame(width: 100, height: 100)
+
+            Text("김민지")
+                .font(.title3)
+                .fontWeight(.semibold)
+        }
+        .padding(.top, 40)
+    }
+}
+
+struct AccountSettingSectionView: View {
+    var body: some View {
+        VStack(spacing: 1) {
+            Text("일반")
+                .font(.title2)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding([.top, .bottom], 16)
+
+            HStack {
+                Text("연결계정")
+                Spacer()
+                HStack(spacing: 5) {
+                    Text("카카오톡")
+                        .foregroundColor(.gray)
+                    Image("kakao_icon") // TODO: 이미지 추가
+                        .resizable()
+                        .frame(width: 20, height: 20)
+                }
+            }
+            .padding()
+            .background(Color(.systemGray6))
+
+            NotificationSettingsView()
+        }
+    }
+}
+
+struct NotificationSettingsView: View {
+    @AppStorage("isNotificationOn") private var isNotificationOn: Bool = false
+    @State private var didLoadStatus = false
+    @State private var showSettingsAlert = false
+
+    var body: some View {
+        Toggle("알림설정", isOn: $isNotificationOn)
+            .onChange(of: isNotificationOn) { newValue in
+                guard didLoadStatus else { return }
+
+                if newValue {
+                    UNUserNotificationCenter.current().getNotificationSettings { settings in
+                        DispatchQueue.main.async {
+                            switch settings.authorizationStatus {
+                            case .notDetermined:
+                                // 아직 요청 안했으면 요청 시도
+                                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+                                    DispatchQueue.main.async {
+                                        isNotificationOn = granted
+                                    }
+                                }
+                            case .denied:
+                                // 권한 거부된 상태 → Alert로 설정 이동 유도
+                                isNotificationOn = false
+                                showSettingsAlert = true
+                            case .authorized, .provisional:
+                                // 이미 허용됨 → 아무 일 없음
+                                break
+                            default:
+                                break
+                            }
+                        }
+                    }
+                } else {
+                    NotificationManager.shared.disableNotifications()
+                }
+            }
+            .onAppear {
+                NotificationManager.shared.fetchNotificationStatus { enabled in
+                    isNotificationOn = enabled
+                    didLoadStatus = true
+                }
+            }
+            .alert("휴대폰 알림이 꺼져 있어요.", isPresented: $showSettingsAlert) {
+                
+                Button("설정하러 가기") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+                Button("취소", role: .cancel) { }
+                
+            } message: {
+                Text("알림 설정을 켜야 챙김 알림을 받을 수 있어요.")
+            }
+            .padding()
+            .background(Color(.systemGray6))
+    }
+}
+
+struct ServiceInfoSectionView: View {
+    var body: some View {
+        VStack(spacing: 1) {
+            Text("서비스 정보")
+                .font(.title2)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 16)
+
+            NavigationLink(destination: Text("서비스 이용 약관")) {
+                serviceRow(title: "서비스 이용 약관")
+            }
+            NavigationLink(destination: Text("개인정보 수집 및 이용 동의서")) {
+                serviceRow(title: "개인정보 수집 및 이용 동의서")
+            }
+            NavigationLink(destination: Text("개인정보 처리방침")) {
+                serviceRow(title: "개인정보 처리방침")
+            }
+        }
+        .padding(.top, 10)
+    }
+
+    private func serviceRow(title: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .foregroundColor(.gray)
+        }
+        .padding()
+        .background(Color(.systemGray6))
+    }
+}
+
+struct WithdrawalButtonView: View {
+    var onWithdrawTap: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Button(action: {
+                // 로그아웃 처리
+            }) {
+                Text("로그아웃")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color.black, lineWidth: 1)
+                    )
+            }
+            .padding(.horizontal)
+
+            Button(action: {
+                onWithdrawTap()
+            }) {
+                Text("탈퇴하기")
+                    .font(.footnote)
+                    .foregroundColor(.gray)
+                    .padding(.bottom, 20)
+            }
+        }
+    }
+}
+
+
+
+struct MyProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        MyProfileView()
+    }
+}

--- a/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
+++ b/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+struct WithdrawalView: View {
+    @Environment(\.presentationMode) var presentationMode
+    @State private var selectedReason: String = ""
+    @State private var customReason: String = ""
+    @FocusState private var isCustomReasonFocused: Bool
+
+    let reasons = [
+        "자주 이용하지 않아요",
+        "신규 계정으로 가입할래요",
+        "개인정보가 우려돼요",
+        "서비스가 불편해요",
+        "기타"
+    ]
+
+    var isValidCustomReason: Bool {
+        selectedReason != "기타" || (customReason.count >= 1 && customReason.count <= 200)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // 상단 헤더
+            HStack {
+                Text("탈퇴하기")
+                    .font(.headline)
+                Spacer()
+                Button(action: {
+                    presentationMode.wrappedValue.dismiss()
+                }) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.black)
+                }
+            }
+            
+            Spacer()
+            // TODO 사람 이름 가져오기
+            Text("김민지님, \n떠나는 이유를 알려주시면 \n큰 도움이 될 거예요.")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text("소중한 의견을 받아 \n더 나은 서비스를 만들어갈게요.")
+                .font(.footnote)
+                .foregroundColor(.gray)
+
+            // 탈퇴 사유 선택
+            ForEach(reasons, id: \.self) { reason in
+                HStack {
+                    Image(systemName: selectedReason == reason ? "largecircle.fill.circle" : "circle")
+                        .foregroundColor(.black)
+                    Text(reason)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    selectedReason = reason
+                    if reason == "기타" {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            isCustomReasonFocused = true // 자동 포커스
+                        }
+                    }
+                }
+            }
+
+            // 기타 선택 시 텍스트필드 노출
+            if selectedReason == "기타" {
+                VStack(alignment: .leading, spacing: 5) {
+                    TextField("탈퇴 사유를 적어주세요", text: Binding(
+                        get: {
+                            String(customReason.prefix(200)) // 200자 제한
+                        },
+                        set: {
+                            customReason = String($0.prefix(200))
+                        })
+                    )
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(8)
+                    .focused($isCustomReasonFocused)
+
+                    // 글자 수 표시
+                    HStack {
+                        Spacer()
+                        Text("\(customReason.count)/200자")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+
+                    // 벨리데이션 문구
+                    if customReason.count < 1 {
+                        Text("1글자 이상 입력해주세요.")
+                            .foregroundColor(.red)
+                            .font(.caption)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // 버튼 영역
+            HStack {
+                Button(action: {
+                    presentationMode.wrappedValue.dismiss()
+                }) {
+                    Text("더 써볼래요")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.black))
+                }
+
+                Button(action: {
+                    submitWithdrawal()
+                }) {
+                    Text("탈퇴하기")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(isValidCustomReason ? Color.black : Color.gray)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+                .disabled(!isValidCustomReason)
+            }
+        }
+        .padding()
+    }
+
+    private func submitWithdrawal() {
+        let reason = selectedReason == "기타" ? customReason : selectedReason
+        guard !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            print("탈퇴 사유 입력 필요")
+            return
+        }
+
+        print("탈퇴 사유:", reason)
+        // 실제 탈퇴 처리 로직
+    }
+}
+
+struct WithdrawalView_Previews: PreviewProvider {
+    static var previews: some View {
+        WithdrawalView()
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항 요약
-  My Page UI 뷰 추가하였습니다

## 📄 작업 내용 상세 설명
-  유저 마이 페이지 기본 유아이 작업하였습니다.
-  유저가 처음 알림 설정을 했을 때 알림 설정 거부를 했으면 이 뷰에서 설정으로 이동하여 알림을 켤 수 있습니다.
-  탈퇴하기를 누르면 full cover로 탈퇴 화면이 보이고 1글자 이상 타입을 해야 제출 할 수 있습니다.

### 🎯 작업 목적
- My Page 기능 추가입니다.

### 🛠️ 주요 변경 사항
- 파일 추가: MyProfileView.swift
- 파일 추가: WithdrawalView.swift

### 📸 스크린샷 (필요시 추가)
<img src="https://github.com/user-attachments/assets/f18eca07-9cfb-4032-98fa-7845cad47ad4" width="40%" />
<img src="https://github.com/user-attachments/assets/f8416510-a13c-42cd-802d-0989cd5d7969" width="40%" />

### ✅ 체크리스트
- [v] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 기타 탈퇴 이유 작성 시 200자 이상 아예 작성 불가하게 하는 옵션, 이유가 늘어나면 가로로 계속 써지는 게 아니라 textfield가 세로로 늘어나는 기능 미 구현
- 서비스 정보 클릭 시 아직 redirect 되지 않아요.
- Usersession 사용하여 이름, 로그인 타입 가져오게 하는 코드 아직 미구현
- 이 뷰에서 알림 껐다가 다시 키게 해서 설정으로 가는 로직 미구현
- 알럿 줄바꿈 추가 필요

### ✅ 참고 이슈 및 관련 작업
.