### PR TITLE
Feature/add contact

### DIFF
--- a/SwypApp2nd/Sources/Common/Date+Extension.swift
+++ b/SwypApp2nd/Sources/Common/Date+Extension.swift
@@ -27,11 +27,37 @@ extension Date {
 
         return formatter.string(from: date)
     }
+    
+    func nextCheckInDateValue(for frequency: CheckInFrequency) -> Date? {
+        let calendar = Calendar.current
+        switch frequency {
+        case .daily:
+            return calendar.date(byAdding: .day, value: 1, to: self)
+        case .weekly:
+            return calendar.date(byAdding: .weekOfYear, value: 1, to: self)
+        case .biweekly:
+            return calendar.date(byAdding: .weekOfYear, value: 2, to: self)
+        case .monthly:
+            return calendar.date(byAdding: .month, value: 1, to: self)
+        case .semiAnnually:
+            return calendar.date(byAdding: .month, value: 6, to: self)
+        default:
+            return nil
+        }
+    }
 
     func weekdayKorean() -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.dateFormat = "EEEE"
+        return formatter.string(from: self)
+    }
+    
+    func formattedYYYYMMDD() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: self)
     }
 }

--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -52,7 +52,6 @@ public struct ContentView: View {
                 ContactFrequencySettingsView(viewModel: contactFrequencyViewModel, back: {
                     userSession.appStep = .registerFriends
                 }, complete: {
-                    // TODO: - BackEnd 서버에 친구 목록 전달해주는 API 호출 필요
                     userSession.appStep = .home
                 })
                 

--- a/SwypApp2nd/Sources/Models/Friend.swift
+++ b/SwypApp2nd/Sources/Models/Friend.swift
@@ -1,8 +1,7 @@
 import Foundation
 import UIKit
 
-// TODO: - Friend로 변경 관계, 생일, 기념일, 메모, 챙김기록..? 추가.
-struct Friend: Identifiable, Equatable, Hashable {
+struct Friend: Identifiable, Equatable, Hashable, Codable {
     var id: UUID
     var name: String
     var image: UIImage?
@@ -10,13 +9,29 @@ struct Friend: Identifiable, Equatable, Hashable {
     var source: ContactSource
     var frequency: CheckInFrequency?
     var remindCategory: RemindCategory?
+    var phoneNumber: String?
+    var relationship: String? // 관계
+    var birthDay: Date? // 생일
+    var anniversary: AnniversaryModel? // 기념일
+    var memo: String? // 메모
     var nextContactAt: Date? // 다음 연락 예정일
     var lastContactAt: Date? // 마지막 연락 일
     var checkRate: Int? // 챙김률
     var position: Int? // 내사람들 리스트 순서
+    
+    enum CodingKeys: String, CodingKey {
+        case id, name, imageURL, source, frequency, remindCategory,
+             relationship, birthDay, anniversary, memo,
+             nextContactAt, lastContactAt, checkRate, position
+    }
 }
 
-enum RemindCategory {
+struct AnniversaryModel: Codable, Equatable, Hashable {
+    var title: String?
+    var Date: Date?
+}
+
+enum RemindCategory: Codable {
     case message
     case birth
     case anniversary
@@ -24,4 +39,156 @@ enum RemindCategory {
 
 enum ContactSource: Codable {
     case phone, kakao
+}
+
+extension Friend {
+    func toInitRequestDTO() -> FriendInitDTO? {
+        // 필수 필드가 없으면 nil 반환
+        guard let frequency = frequency,
+              let nextDate = nextContactAt,
+              let contactWeek = frequency.toContactWeek(),
+              let sourceString = source.toServerValue()
+        else {
+            print("🔴 필수 값 누락: frequency=\(String(describing: frequency)), nextContactAt=\(String(describing: nextContactAt)), source=\(source)")
+            return nil
+        }
+        
+        print("🟢 toInitRequestDTO 변환 시작 for: \(name)")
+        
+        let dayOfWeek = nextDate.dayOfWeekString()
+
+        // 이미지 업로드 정보가 필요한 경우에만 포함
+        let imageUploadRequest: ImageUploadRequestDTO? = {
+            guard let image = image,
+                  let imageData = image.jpegData(compressionQuality: 0.8)
+            else { return nil }
+
+            return ImageUploadRequestDTO(
+                fileName: "\(id).jpg",
+                contentType: "image/jpeg",
+                fileSize: imageData.count,
+                category: "Friends/profile"
+            )
+        }()
+
+        let anniversaryDTO: AnniversaryDTO? = {
+            guard let anniversary = anniversary,
+                  let title = anniversary.title,
+                  let date = anniversary.Date
+            else { return nil }
+
+            let formatted = date.formattedYYYYMMDD()
+            return AnniversaryDTO(title: title, date: formatted)
+        }()
+        
+//        let birthDayString = birthDay?.formattedYYYYMMDD()
+
+        return FriendInitDTO(
+            name: name,
+            source: sourceString,
+            contactFrequency: ContactFrequencyDTO(
+                contactWeek: contactWeek,
+                dayOfWeek: dayOfWeek
+            ),
+            imageUploadRequest: imageUploadRequest,
+            anniversary: anniversaryDTO,
+//            birthDay: birthDayString,
+            phone: phoneNumber
+        )
+    }
+}
+
+extension ContactSource {
+    func toServerValue() -> String? {
+        switch self {
+        case .phone: return "APPLE"
+        case .kakao: return "KAKAO"
+        }
+    }
+}
+
+extension CheckInFrequency {
+    func toContactWeek() -> String? {
+        switch self {
+        case .daily: return "EVERY_DAY"
+        case .weekly: return "EVERY_WEEK"
+        case .biweekly: return "EVERY_2WEEK"
+        case .monthly: return "EVERY_MONTH"
+        case .semiAnnually: return "EVERY_6MONTH"
+        default: return nil
+        }
+    }
+}
+
+extension Date {
+    func dayOfWeekString() -> String {
+        let calendar = Calendar.current
+        let weekday = calendar.component(.weekday, from: self)
+
+        // 일요일 = 1, 토요일 = 7
+        switch weekday {
+        case 1: return "SUNDAY"
+        case 2: return "MONDAY"
+        case 3: return "TUESDAY"
+        case 4: return "WEDNESDAY"
+        case 5: return "THURSDAY"
+        case 6: return "FRIDAY"
+        case 7: return "SATURDAY"
+        default: return "MONDAY"
+        }
+    }
+}
+
+extension ISO8601DateFormatter {
+    func formatDateOnly(_ date: Date) -> String {
+        self.formatOptions = [.withFullDate]
+        return self.string(from: date)
+    }
+}
+
+struct FriendInitRequestDTO: Codable {
+    let friendList: [FriendInitDTO]
+}
+
+struct FriendInitDTO: Codable {
+    let name: String
+    let source: String
+    let contactFrequency: ContactFrequencyDTO
+    let imageUploadRequest: ImageUploadRequestDTO?
+    let anniversary: AnniversaryDTO?
+//    let birthDay: String?
+    // TODO: - relationship 포함되어야함
+    let phone: String?
+}
+
+struct ContactFrequencyDTO: Codable {
+    let contactWeek: String
+    let dayOfWeek: String
+}
+
+struct ImageUploadRequestDTO: Codable {
+    let fileName: String
+    let contentType: String
+    let fileSize: Int
+    let category: String
+}
+
+struct AnniversaryDTO: Codable {
+    let title: String
+    let date: String
+}
+
+struct FriendInitResponseDTO: Codable {
+    let friendList: [FriendWithUploadURL]
+}
+
+struct FriendWithUploadURL: Codable {
+    let friendId: String
+    let name: String
+    let source: String
+    let contactFrequency: ContactFrequencyDTO
+    let phone: String?
+    let nextContactAt: String?
+    let preSignedImageUrl: String?
+    let anniversary: AnniversaryDTO?
 }

--- a/SwypApp2nd/Sources/Models/Friend.swift
+++ b/SwypApp2nd/Sources/Models/Friend.swift
@@ -1,8 +1,8 @@
 import Foundation
 import UIKit
 
-// TODO: - Friend로 변경
-struct Contact: Identifiable, Equatable, Hashable {
+// TODO: - Friend로 변경 관계, 생일, 기념일, 메모, 챙김기록..? 추가.
+struct Friend: Identifiable, Equatable, Hashable {
     var id: UUID
     var name: String
     var image: UIImage?

--- a/SwypApp2nd/Sources/Models/User.swift
+++ b/SwypApp2nd/Sources/Models/User.swift
@@ -5,6 +5,7 @@ struct User: Codable, Identifiable {
     var name: String  // 이름
     var email: String?  // 이메일
     var profileImageURL: String?  // 프로필 사진 URL
+    var friends: [Friend] // 챙길 친구들
     var loginType: LoginType  // 애플, 카카오
     let serverAccessToken: String // 서버 access token
     let serverRefreshToken: String // 서버 refresh token

--- a/SwypApp2nd/Sources/Services/SnsAuthService.swift
+++ b/SwypApp2nd/Sources/Services/SnsAuthService.swift
@@ -32,7 +32,29 @@ class SnsAuthService {
             }
         }
     }
-
+    
+    /// 카카오 이미지 저장
+    func downloadImageData(from urlString: String, completion: @escaping (Data?) -> Void) {
+        guard let url = URL(string: urlString) else {
+            print("🔴 [SnsAuthService] 잘못된 URL")
+            completion(nil)
+            return
+        }
+        
+        AF.request(url)
+            .validate()
+            .responseData { response in
+                switch response.result {
+                case .success(let data):
+                    print("🟢 [SnsAuthService] 이미지 다운로드 성공, size: \(data.count) bytes")
+                    completion(data)
+                case .failure(let error):
+                    print("🔴 [SnsAuthService] 이미지 다운로드 실패: \(error)")
+                    completion(nil)
+                }
+            }
+    }
+    
     /// 애플 로그인 요청 세팅
     func configureAppleRequest(_ request: ASAuthorizationAppleIDRequest) {
         request.requestedScopes = [.fullName, .email]

--- a/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 
 class HomeViewModel: ObservableObject {
-    @Published var peoples: [Contact] = []
+    @Published var peoples: [Friend] = []
     
 //    init() {
 //        loadPeoplesFromUserSession()

--- a/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import UIKit
 
-enum CheckInFrequency: String, CaseIterable, Identifiable {
+enum CheckInFrequency: String, CaseIterable, Identifiable, Codable {
     case none = "주기 선택"
     case daily = "매일"
     case weekly = "매주"
@@ -34,9 +34,15 @@ class ContactFrequencySettingsViewModel: ObservableObject {
         isUnified = enabled
     }
     
+    func calculateNextContactDate(for frequency: CheckInFrequency) -> Date {
+        return Date().nextCheckInDateValue(for: frequency) ?? Date()
+    }
+    
     func updateFrequency(for person: Friend, to frequency: CheckInFrequency) {
         guard let index = people.firstIndex(of: person) else { return }
+        let nextDate = calculateNextContactDate(for: frequency)
         people[index].frequency = frequency
+        people[index].nextContactAt = nextDate
     }
     
     func applyUnifiedFrequency(_ frequency: CheckInFrequency) {
@@ -52,6 +58,55 @@ class ContactFrequencySettingsViewModel: ObservableObject {
     func setPeople(from contacts: [Friend]) {
         self.people = contacts.map {
             Friend(id: $0.id, name: $0.name, image: $0.image, source: $0.source, frequency: $0.frequency)
+        }
+    }
+    
+    /// 카카오 이미지 다운로드
+    func downloadKakaoImageData(completion: @escaping ([Friend]) -> Void) {
+        var updatedPeople = people
+        let group = DispatchGroup()
+        
+        for (index, friend) in people
+            .enumerated() where friend.source == .kakao {
+            guard let urlString = friend.imageURL else { continue }
+            group.enter()
+            
+            SnsAuthService.shared.downloadImageData(from: urlString) { data in
+                if let data = data, let image = UIImage(data: data) {
+                    updatedPeople[index].image = image
+                    print("🟢 [ContactFrequencySettingsViewModel] \(friend.name) 이미지 다운로드 성공")
+                } else {
+                    print("🔴 [ContactFrequencySettingsViewModel] \(friend.name) 이미지 다운로드 실패")
+                }
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            self.people = updatedPeople
+            completion(updatedPeople)
+        }
+    }
+    
+    func uploadAllFriendsToServer(_ friends: [Friend]) {
+        guard let accessToken = UserSession.shared.user?.serverAccessToken else { return }
+        
+        BackEndAuthService.shared.sendInitialFriends(friends: friends, accessToken: accessToken) { result in
+            switch result {
+            case .success(let registeredFriends):
+                for friendWithURL in registeredFriends {
+                    if let url = friendWithURL.preSignedImageUrl,
+                       let localFriend = friends.first(where: { $0.name == friendWithURL.name }),
+                       let image = localFriend.image?.jpegData(compressionQuality: 0.8) {
+                        
+                        BackEndAuthService.shared.uploadImageWithPresignedURL(imageData: image, presignedURL: url, contentType: "image/jpeg") { success in
+                            print("▶️ \(friendWithURL.name)의 이미지 업로드: \(success ? "성공" : "실패")")
+                        }
+                    }
+                }
+            case .failure(let error):
+                print("🔴 [ContactFrequencySettingsViewModel] 친구 등록 실패: \(error)")
+            }
         }
     }
 }

--- a/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
@@ -14,7 +14,7 @@ enum CheckInFrequency: String, CaseIterable, Identifiable {
 }
 
 class ContactFrequencySettingsViewModel: ObservableObject {
-    @Published var people: [Contact] = []
+    @Published var people: [Friend] = []
     @Published var isUnified: Bool = false
     @Published var unifiedFrequency: CheckInFrequency? = nil
     
@@ -34,7 +34,7 @@ class ContactFrequencySettingsViewModel: ObservableObject {
         isUnified = enabled
     }
     
-    func updateFrequency(for person: Contact, to frequency: CheckInFrequency) {
+    func updateFrequency(for person: Friend, to frequency: CheckInFrequency) {
         guard let index = people.firstIndex(of: person) else { return }
         people[index].frequency = frequency
     }
@@ -43,15 +43,15 @@ class ContactFrequencySettingsViewModel: ObservableObject {
         unifiedFrequency = frequency
         if isUnified {
             people = people.map {
-                Contact(id: $0.id, name: $0.name, image: $0.image, source: $0.source, frequency: frequency)
+                Friend(id: $0.id, name: $0.name, image: $0.image, source: $0.source, frequency: frequency)
             }
         }
     }
     
     // RegisterViewModel에서 선택한 연락처 받아오는 메소드
-    func setPeople(from contacts: [Contact]) {
+    func setPeople(from contacts: [Friend]) {
         self.people = contacts.map {
-            Contact(id: $0.id, name: $0.name, image: $0.image, source: $0.source, frequency: $0.frequency)
+            Friend(id: $0.id, name: $0.name, image: $0.image, source: $0.source, frequency: $0.frequency)
         }
     }
 }

--- a/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
@@ -48,9 +48,9 @@ class LoginViewModel: ObservableObject {
                             )
                         // TODO: - id, name 서버에서 받을건지 요청
                         let user = User(
-                            id: "",
+                            id: UUID().uuidString,
                             name: "",
-                            loginType: .kakao,
+                            friends: [], loginType: .kakao,
                             serverAccessToken: tokenResponse.accessToken,
                             serverRefreshToken: tokenResponse.refreshTokenInfo.token
                         )
@@ -104,7 +104,7 @@ class LoginViewModel: ObservableObject {
                             let user = User(
                                 id: "",
                                 name: "",
-                                loginType: .apple,
+                                friends: [], loginType: .apple,
                                 serverAccessToken: tokenResponse.accessToken,
                                 serverRefreshToken: tokenResponse.refreshTokenInfo.token
                             )

--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -7,7 +7,7 @@ import Combine
 import Contacts
 
 class RegisterFriendsViewModel: ObservableObject {
-    @Published var selectedContacts: [Contact] = []
+    @Published var selectedContacts: [Friend] = []
     
     private let contactStore = CNContactStore()
     
@@ -15,21 +15,21 @@ class RegisterFriendsViewModel: ObservableObject {
         !selectedContacts.isEmpty
     }
 
-    func addContact(_ contact: Contact) {
+    func addContact(_ contact: Friend) {
         guard selectedContacts.count < 10 else { return }
         guard !selectedContacts.contains(contact) else { return }
         selectedContacts.append(contact)
     }
 
-    func removeContact(_ contact: Contact) {
+    func removeContact(_ contact: Friend) {
         selectedContacts.removeAll { $0 == contact }
     }
     
-    var phoneContacts: [Contact] {
+    var phoneContacts: [Friend] {
         selectedContacts.filter { $0.source == .phone }
     }
 
-    var kakaoContacts: [Contact] {
+    var kakaoContacts: [Friend] {
         selectedContacts.filter { $0.source == .kakao }
     }
     
@@ -47,10 +47,10 @@ class RegisterFriendsViewModel: ObservableObject {
     }
     
     func handleSelectedContacts(_ contacts: [CNContact]) {
-        let converted: [Contact] = contacts.compactMap {
+        let converted: [Friend] = contacts.compactMap {
             let name = $0.familyName + $0.givenName
             let image = $0.thumbnailImageData.flatMap { UIImage(data: $0) }
-            return Contact(id: UUID(), name: name, image: image, source: .phone, frequency: CheckInFrequency.none)
+            return Friend(id: UUID(), name: name, image: image, source: .phone, frequency: CheckInFrequency.none)
         }
         DispatchQueue.main.async {
             let existingNonPhone = self.selectedContacts.filter { $0.source != .phone }
@@ -117,11 +117,11 @@ class RegisterFriendsViewModel: ObservableObject {
                 )
                 
                 // TODO: - 썸네일 이미지 URL → Signed URL 적용
-                let kakaoContacts: [Contact] = selectedUsers.compactMap {
-                    Contact(
+                let kakaoContacts: [Friend] = selectedUsers.compactMap {
+                    Friend(
                         id: UUID(),
                         name: $0.profileNickname ?? "이름 없음",
-                        image: nil,
+                        image: nil, // $0.profileThumbnailImage 은 urlString
                         source: .kakao,
                         frequency: CheckInFrequency.none
                     )

--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -50,7 +50,30 @@ class RegisterFriendsViewModel: ObservableObject {
         let converted: [Friend] = contacts.compactMap {
             let name = $0.familyName + $0.givenName
             let image = $0.thumbnailImageData.flatMap { UIImage(data: $0) }
-            return Friend(id: UUID(), name: name, image: image, source: .phone, frequency: CheckInFrequency.none)
+            let birthDay = $0.birthday?.date
+            let anniversaryDay = $0.dates.first?.value as? Date
+            let anniversaryDayTitle = $0.dates.first?.label
+            let relationship = $0.contactRelations.first?.value
+            let phoneNumber =  $0.phoneNumbers.first?.value.stringValue
+            return Friend(
+                        id: UUID(),
+                        name: name,
+                        image: image,
+                        imageURL: nil,
+                        source: .phone,
+                        frequency: CheckInFrequency.none,
+                        remindCategory: nil,
+                        phoneNumber: phoneNumber,
+                        relationship: relationship?.name,
+                        birthDay: birthDay,
+                        anniversary: AnniversaryModel(
+                            title: anniversaryDayTitle ?? nil,
+                            Date: anniversaryDay ?? nil),
+                        nextContactAt: nil,
+                        lastContactAt: nil,
+                        checkRate: nil,
+                        position: nil
+                    )
         }
         DispatchQueue.main.async {
             let existingNonPhone = self.selectedContacts.filter { $0.source != .phone }
@@ -121,7 +144,7 @@ class RegisterFriendsViewModel: ObservableObject {
                     Friend(
                         id: UUID(),
                         name: $0.profileNickname ?? "이름 없음",
-                        image: nil, // $0.profileThumbnailImage 은 urlString
+                        imageURL: $0.profileThumbnailImage?.absoluteString,
                         source: .kakao,
                         frequency: CheckInFrequency.none
                     )

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -131,7 +131,7 @@ struct GreetingSection: View {
 
 // MARK: - 이번달 챙길 사람
 struct ThisMonthSection: View {
-    var peoples: [Contact]
+    var peoples: [Friend]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -183,8 +183,8 @@ struct ThisMonthSection: View {
 }
 
 struct ThisMonthContactCell: View {
-    let contact: Contact
-    let onTap: (Contact) -> Void
+    let contact: Friend
+    let onTap: (Friend) -> Void
 
     var body: some View {
         Button {
@@ -254,8 +254,8 @@ struct ThisMonthContactCell: View {
 // MARK: - 내 사람들
 struct MyPeopleSection: View {
     @State private var currentPage = 0
-    @State var peoples: [Contact]
-    private var pages: [[Contact]] {
+    @State var peoples: [Friend]
+    private var pages: [[Friend]] {
         stride(from: 0, to: peoples.count, by: 5).map {
             Array(peoples[$0..<min($0 + 5, peoples.count)])
         }
@@ -327,9 +327,9 @@ struct MyPeopleSection: View {
 }
 
 struct StarPositionLayout: View {
-    @Binding var peoples: [Contact]
+    @Binding var peoples: [Friend]
     let pageIndex: Int
-    let onTap: (Contact) -> Void
+    let onTap: (Friend) -> Void
         
     @State private var dragOffset: CGSize = .zero
     @State private var draggingIndex: Int? = nil
@@ -422,8 +422,8 @@ struct StarPositionLayout: View {
 }
 
 struct PersonCircleView: View {
-    let people: Contact
-    let onTap: (Contact) -> Void
+    let people: Friend
+    let onTap: (Friend) -> Void
     
     var emojiImageName: String {
         guard let rate = people.checkRate else {
@@ -518,7 +518,7 @@ struct HomeView_Previews: PreviewProvider {
         let viewModel: HomeViewModel = {
             let vm = HomeViewModel()
             vm.peoples = [
-                Contact(
+                Friend(
                     id: UUID(),
                     name: "정종원1",
                     image: nil,
@@ -533,7 +533,7 @@ struct HomeView_Previews: PreviewProvider {
                     checkRate: 20,
                     position: 0
                 ),
-                Contact(
+                Friend(
                     id: UUID(),
                     name: "정종원2",
                     image: nil,
@@ -548,7 +548,7 @@ struct HomeView_Previews: PreviewProvider {
                     checkRate: 45,
                     position: 1
                 ),
-                Contact(
+                Friend(
                     id: UUID(),
                     name: "정종원3",
                     image: nil,
@@ -563,7 +563,7 @@ struct HomeView_Previews: PreviewProvider {
                     checkRate: 65,
                     position: 2
                 ),
-                Contact(
+                Friend(
                     id: UUID(),
                     name: "정종원4",
                     image: nil,
@@ -578,7 +578,7 @@ struct HomeView_Previews: PreviewProvider {
                     checkRate: 85,
                     position: 3
                 ),
-                Contact(
+                Friend(
                     id: UUID(),
                     name: "정종원5",
                     image: nil,
@@ -593,7 +593,7 @@ struct HomeView_Previews: PreviewProvider {
                     checkRate: 30,
                     position: 4
                 ),
-                Contact(
+                Friend(
                     id: UUID(),
                     name: "정종원6",
                     image: nil,
@@ -608,7 +608,7 @@ struct HomeView_Previews: PreviewProvider {
                     checkRate: 85,
                     position: 3
                 ),
-                Contact(
+                Friend(
                     id: UUID(),
                     name: "정종원7",
                     image: nil,

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ContactFrequencySettingsView: View {
     @ObservedObject var viewModel: ContactFrequencySettingsViewModel
-    @State private var selectedPerson: Contact?
+    @State private var selectedPerson: Friend?
     @State private var showFrequencyPicker: Bool = false
     
     let back: () -> Void
@@ -154,7 +154,7 @@ struct ContactFrequencySettingsView: View {
 
 // MARK: - 사람별 주기설정 셀
 struct FrequencyRow: View {
-    let person: Contact
+    let person: Friend
     let isUnified: Bool
     let onSelect: () -> Void
 
@@ -303,12 +303,12 @@ struct FrequencyPickerView: View {
     let viewModel: ContactFrequencySettingsViewModel = {
         let vm = ContactFrequencySettingsViewModel()
         vm.people = [
-            Contact(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-            Contact(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-            Contact(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-            Contact(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
-            Contact(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
-            Contact(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none)
+            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
+            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
+            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
+            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
+            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
+            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none)
         ]
         return vm
     }()

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -118,7 +118,17 @@ struct ContactFrequencySettingsView: View {
                         )
                 }
 
-                Button(action: complete) {
+                Button{
+                    // 카카오는 이미지 저장 후 BackEnd 서버에 전송
+                    viewModel.downloadKakaoImageData { friendsWithImages in
+                        DispatchQueue.main.async {
+                            viewModel.uploadAllFriendsToServer(friendsWithImages)
+                        }
+                        
+                    }
+                    complete()
+                }
+                label: {
                     Text("완료")
                         .font(.body.bold())
                         .foregroundColor(.white)

--- a/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
@@ -177,7 +177,7 @@ struct CardButton: View {
 
 // MARK: - 가져온 연락처 Row
 struct ContactRow: View {
-    let contact: Contact
+    let contact: Friend
     let onDelete: () -> Void
 
     var iconImage: Image {

--- a/SwypApp2nd/Tests/SwypApp2ndTests.swift
+++ b/SwypApp2nd/Tests/SwypApp2ndTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import KakaoSDKAuth
 import XCTest
+//import Alamofire
 //@testable import SwypApp2nd
 //
 //final class SwypApp2ndTests: XCTestCase {
@@ -76,3 +77,63 @@ import XCTest
 //    }
 //}
 //
+//
+//final class ContactFrequencySettingsViewModelTests: XCTestCase {
+//    var viewModel: ContactFrequencySettingsViewModel!
+//
+//    override func setUp() {
+//        super.setUp()
+//        viewModel = ContactFrequencySettingsViewModel()
+//
+//        // 임시 사용자 토큰 설정
+//        let mockUser = User(
+//            id: "user-id",
+//            name: "Test User",
+//            email: "test@example.com",
+//            profileImageURL: nil,
+//            friends: [],
+//            loginType: .kakao,
+//            serverAccessToken: "",
+//            serverRefreshToken: "REFRESH_TOKEN"
+//        )
+//        UserSession.shared.user = mockUser
+//    }
+//
+//    func testUploadAllFriendsToServer() {
+//        // Given: 테스트용 Friend
+//        let friend = Friend(
+//            id: UUID(),
+//            name: "테스트 친구",
+//            image: UIImage(systemName: "person"),
+//            imageURL: nil,
+//            source: .kakao,
+//            frequency: .weekly,
+//            remindCategory: nil,
+//            phoneNumber: "01012345678",
+//            relationship: "친구",
+//            birthDay: Date(),
+//            anniversary: nil,
+//            memo: "테스트 메모",
+//            nextContactAt: Date(),
+//            lastContactAt: nil,
+//            checkRate: nil,
+//            position: 1
+//        )
+//
+//        let expectation = self.expectation(description: "업로드 완료")
+//        
+//        print("📦 테스트 시작: 서버에 Friend 업로드를 시도합니다.")
+//        
+//        // When
+//        viewModel.uploadAllFriendsToServer([friend])
+//
+//        // 서버에 전송 확인은 콘솔 출력 or 로그 확인 필요
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+//            print("🟢 테스트 완료: 서버 응답 로그를 확인하세요.")
+//            expectation.fulfill()
+//        }
+//
+//        // Then
+//        waitForExpectations(timeout: 5.0, handler: nil)
+//    }
+//}


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 연락처 추가 및 주기 설정 시 Friend 모델 기반의 서버 연동 로직 구현
- Kakao/Apple 연락처로부터 이미지 및 메타데이터 추출 후 presigned URL을 통한 업로드 처리
- 기존 Contact → Friend 구조로 전환 및 관련 모델/로직 리팩터링
- 주기 설정 완료 시 서버에 Friend 초기화 API 호출

## 📄 작업 내용 상세 설명
- 모델 통합 및 리팩토링
    - 기존 Contact → Friend로 전환
    - Friend.swift에 서버 연동용 DTO(FriendInitDTO) 추가
    - User 모델에 friends: [Friend] 필드 추가
- Presigned URL 기반 업로드 처리
    - BackEndAuthService에 sendInitialFriends, uploadImageWithPresignedURL 추가
    - Kakao 이미지 다운로드 후 서버에서 받은 presigned URL로 이미지 업로드 진행
- 주기 설정 기능과 서버 연동 연결
    - ContactFrequencySettingsViewModel에서 frequency 선택 시 nextContactAt 자동 계산
    - 완료 버튼 클릭 시 서버에 친구 등록 API 호출 및 이미지 업로드
- 추가 작업
    - DateExtension: .nextCheckInDateValue(for:), .formattedYYYYMMDD() 구현
    - 테스트 코드 추가: ContactFrequencySettingsViewModelTests.testUploadAllFriendsToServer()

### 🎯 작업 목적
- 사용자가 선택한 연락처 데이터를 기반으로 주기 설정 및 초기 서버 연동을 완료하기 위함
- Kakao/Apple 연락처 정보를 바탕으로 이미지까지 포함된 사용자 정의 Friend 정보 등록 가능하도록 개선

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 이미지 업로드는 presigned URL이 응답에 포함되어야만 성공합니다.
- Kakao에서 이미지 URL을 String으로 받기 때문에 다운로드 후 이미지 데이터로 변환 필요
- iOS 연락처에서 가져온 연락처의 생일/기념일 등은 일부 nil일 수 있습니다.

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: https://github.com/SWYP-App-2nd/iOS/issues/8