### PR TITLE
[Feature] 사람 추가, 로컬 기준 연락처 사용

### DIFF
--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -51,8 +51,13 @@ public struct ContentView: View {
             case .setFrequency:
                 ContactFrequencySettingsView(viewModel: contactFrequencyViewModel, back: {
                     userSession.appStep = .registerFriends
-                }, complete: {
-                    userSession.appStep = .home
+                }, complete: { updatedPeoples in
+                    DispatchQueue.main.async {
+                        print("🟢 [ContactFrequencySettingsView] 전달받은 people: \(updatedPeoples.map { $0.name })")
+                        homeViewModel.peoples = updatedPeoples
+                        UserSession.shared.user?.friends = updatedPeoples
+                        userSession.appStep = .home
+                    }
                 })
                 
             case .home:

--- a/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
@@ -3,13 +3,18 @@ import Combine
 
 class HomeViewModel: ObservableObject {
     @Published var peoples: [Friend] = []
+    /// 내 사람들
+    @Published var allFriends: [Friend] = []
+    /// 이번달 챙길 사람
+    @Published var thisMonthFriends: [Friend] = []
     
-//    init() {
-//        loadPeoplesFromUserSession()
-//    }
-//
-//    @MainActor
-//    func loadPeoplesFromUserSession() {
-//        self.peoples = UserSession.shared.user?.contacts ?? []
-//    }
+    init() {
+        loadPeoplesFromUserSession()
+    }
+
+    func loadPeoplesFromUserSession() {
+        DispatchQueue.main.async {
+            self.peoples = UserSession.shared.user?.friends ?? []
+        }
+    }
 }

--- a/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
@@ -48,8 +48,9 @@ class ContactFrequencySettingsViewModel: ObservableObject {
     func applyUnifiedFrequency(_ frequency: CheckInFrequency) {
         unifiedFrequency = frequency
         if isUnified {
+            let nextDate = calculateNextContactDate(for: frequency)
             people = people.map {
-                Friend(id: $0.id, name: $0.name, image: $0.image, source: $0.source, frequency: frequency)
+                Friend(id: $0.id, name: $0.name, image: $0.image, source: $0.source, frequency: frequency, nextContactAt: nextDate)
             }
         }
     }

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -198,6 +198,10 @@ struct ThisMonthContactCell: View {
                     Image(iconName)
                         .resizable()
                         .frame(width: 24, height: 24)
+                } else {
+                    Image("icon_visual_mail")
+                        .resizable()
+                        .frame(width: 24, height: 24)
                 }
 
                 Text(contact.name)
@@ -368,6 +372,7 @@ struct StarPositionLayout: View {
         ZStack {
             let start = pageIndex * 5
             let end = min(start + 5, peoples.count)
+            let pagePeople = Array(peoples[start..<end])
             ForEach(start..<end, id: \.self) { i in
                 let indexInPage = i - start
                 let person = peoples[i]
@@ -437,6 +442,29 @@ struct StarPositionLayout: View {
                             }
                     )
                     .animation(.spring(), value: dragOffset)
+            }
+            // 추가 버튼 삽입 로직
+            if pagePeople.count < 5 {
+                let addIndex = pagePeople.count
+                Button {
+                    UserSession.shared.appStep = .registerFriends
+                } label: {
+                    VStack {
+                        Image(systemName: "plus")
+                            .font(.title)
+                            .foregroundColor(.blue)
+                            .frame(width: 64, height: 64)
+                            .background(Color.bg01)
+                            .clipShape(Circle())
+                        Text("사람 추가")
+                            .font(Font.Pretendard.b1Medium())
+                            .foregroundColor(.black)
+                    }
+                }
+                .offset(
+                    x: positions[addIndex].x,
+                    y: positions[addIndex].y
+                )
             }
         }
         .frame(height: 240)
@@ -537,117 +565,118 @@ struct HomeView_Previews: PreviewProvider {
     }
     
     static func previewForDevice(_ deviceName: String) -> some View {
-        let viewModel: HomeViewModel = {
-            let vm = HomeViewModel()
-            vm.peoples = [
-                Friend(
-                    id: UUID(),
-                    name: "정종원1",
-                    image: nil,
-                    imageURL: nil,
-                    source: .kakao,
-                    frequency: CheckInFrequency.none,
-                    remindCategory: .message,
-                    nextContactAt: Calendar.current
-                        .date(byAdding: .day, value: 0, to: Date()), // 오늘
-                    lastContactAt: Calendar.current
-                        .date(byAdding: .day, value: -1, to: Date()),
-                    checkRate: 20,
-                    position: 0
-                ),
-                Friend(
-                    id: UUID(),
-                    name: "정종원2",
-                    image: nil,
-                    imageURL: nil,
-                    source: .phone,
-                    frequency: CheckInFrequency.none,
-                    remindCategory: .anniversary,
-                    nextContactAt: Calendar.current
-                        .date(byAdding: .day, value: 2, to: Date()), // D-2
-                    lastContactAt: Calendar.current
-                        .date(byAdding: .day, value: -3, to: Date()),
-                    checkRate: 45,
-                    position: 1
-                ),
-                Friend(
-                    id: UUID(),
-                    name: "정종원3",
-                    image: nil,
-                    imageURL: nil,
-                    source: .kakao,
-                    frequency: CheckInFrequency.none,
-                    remindCategory: .message,
-                    nextContactAt: Calendar.current
-                        .date(byAdding: .day, value: -1, to: Date()), // D+1
-                    lastContactAt: Calendar.current
-                        .date(byAdding: .day, value: -7, to: Date()),
-                    checkRate: 65,
-                    position: 2
-                ),
-                Friend(
-                    id: UUID(),
-                    name: "정종원4",
-                    image: nil,
-                    imageURL: nil,
-                    source: .phone,
-                    frequency: CheckInFrequency.none,
-                    remindCategory: .message,
-                    nextContactAt: Calendar.current
-                        .date(byAdding: .day, value: 7, to: Date()), // D-7
-                    lastContactAt: Calendar.current
-                        .date(byAdding: .day, value: -10, to: Date()),
-                    checkRate: 85,
-                    position: 3
-                ),
-                Friend(
-                    id: UUID(),
-                    name: "정종원5",
-                    image: nil,
-                    imageURL: nil,
-                    source: .phone,
-                    frequency: CheckInFrequency.none,
-                    remindCategory: .birth,
-                    nextContactAt: Calendar.current
-                        .date(byAdding: .day, value: 15, to: Date()), // D-15
-                    lastContactAt: Calendar.current
-                        .date(byAdding: .day, value: -14, to: Date()),
-                    checkRate: 30,
-                    position: 4
-                ),
-                Friend(
-                    id: UUID(),
-                    name: "정종원6",
-                    image: nil,
-                    imageURL: nil,
-                    source: .phone,
-                    frequency: CheckInFrequency.none,
-                    remindCategory: .message,
-                    nextContactAt: Calendar.current
-                        .date(byAdding: .day, value: 7, to: Date()), // D-7
-                    lastContactAt: Calendar.current
-                        .date(byAdding: .day, value: -10, to: Date()),
-                    checkRate: 85,
-                    position: 3
-                ),
-                Friend(
-                    id: UUID(),
-                    name: "정종원7",
-                    image: nil,
-                    imageURL: nil,
-                    source: .phone,
-                    frequency: CheckInFrequency.none,
-                    remindCategory: .birth,
-                    nextContactAt: Calendar.current
-                        .date(byAdding: .day, value: 15, to: Date()), // D-15
-                    lastContactAt: Calendar.current
-                        .date(byAdding: .day, value: -14, to: Date()),
-                    checkRate: 30,
-                    position: 4
-                )
-            ]
-            return vm
-        }()
+        let fakeFriends = [
+            Friend(
+                id: UUID(),
+                name: "정종원1",
+                image: nil,
+                imageURL: nil,
+                source: .kakao,
+                frequency: CheckInFrequency.none,
+                remindCategory: .message,
+                nextContactAt: Calendar.current
+                    .date(byAdding: .day, value: 0, to: Date()), // 오늘
+                lastContactAt: Calendar.current
+                    .date(byAdding: .day, value: -1, to: Date()),
+                checkRate: 20,
+                position: 0
+            ),
+            Friend(
+                id: UUID(),
+                name: "정종원2",
+                image: nil,
+                imageURL: nil,
+                source: .phone,
+                frequency: CheckInFrequency.none,
+                remindCategory: .anniversary,
+                nextContactAt: Calendar.current
+                    .date(byAdding: .day, value: 2, to: Date()), // D-2
+                lastContactAt: Calendar.current
+                    .date(byAdding: .day, value: -3, to: Date()),
+                checkRate: 45,
+                position: 1
+            ),
+            Friend(
+                id: UUID(),
+                name: "정종원3",
+                image: nil,
+                imageURL: nil,
+                source: .kakao,
+                frequency: CheckInFrequency.none,
+                remindCategory: .message,
+                nextContactAt: Calendar.current
+                    .date(byAdding: .day, value: -1, to: Date()), // D+1
+                lastContactAt: Calendar.current
+                    .date(byAdding: .day, value: -7, to: Date()),
+                checkRate: 65,
+                position: 2
+            ),
+            Friend(
+                id: UUID(),
+                name: "정종원4",
+                image: nil,
+                imageURL: nil,
+                source: .phone,
+                frequency: CheckInFrequency.none,
+                remindCategory: .message,
+                nextContactAt: Calendar.current
+                    .date(byAdding: .day, value: 7, to: Date()), // D-7
+                lastContactAt: Calendar.current
+                    .date(byAdding: .day, value: -10, to: Date()),
+                checkRate: 85,
+                position: 3
+            ),
+            Friend(
+                id: UUID(),
+                name: "정종원5",
+                image: nil,
+                imageURL: nil,
+                source: .phone,
+                frequency: CheckInFrequency.none,
+                remindCategory: .birth,
+                nextContactAt: Calendar.current
+                    .date(byAdding: .day, value: 15, to: Date()), // D-15
+                lastContactAt: Calendar.current
+                    .date(byAdding: .day, value: -14, to: Date()),
+                checkRate: 30,
+                position: 4
+            ),
+            Friend(
+                id: UUID(),
+                name: "정종원6",
+                image: nil,
+                imageURL: nil,
+                source: .phone,
+                frequency: CheckInFrequency.none,
+                remindCategory: .message,
+                nextContactAt: Calendar.current
+                    .date(byAdding: .day, value: 7, to: Date()), // D-7
+                lastContactAt: Calendar.current
+                    .date(byAdding: .day, value: -10, to: Date()),
+                checkRate: 85,
+                position: 3
+            ),
+            Friend(
+                id: UUID(),
+                name: "정종원7",
+                image: nil,
+                imageURL: nil,
+                source: .phone,
+                frequency: CheckInFrequency.none,
+                remindCategory: .birth,
+                nextContactAt: Calendar.current
+                    .date(byAdding: .day, value: 15, to: Date()), // D-15
+                lastContactAt: Calendar.current
+                    .date(byAdding: .day, value: -14, to: Date()),
+                checkRate: 30,
+                position: 4
+            )
+        ]
+        
+        UserSession.shared.user = User(id: "", name: "프리뷰", friends: fakeFriends, loginType: .kakao, serverAccessToken: "", serverRefreshToken: "")
+        
+        let viewModel = HomeViewModel()
+        viewModel.loadPeoplesFromUserSession()
         
         return HomeView(
             homeViewModel: viewModel,

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -258,6 +258,7 @@ struct ThisMonthContactCell: View {
 struct MyPeopleSection: View {
     @State private var currentPage = 0
     @State var peoples: [Friend]
+    @State private var showEllipsisOptions = false
     private var pages: [[Friend]] {
         stride(from: 0, to: peoples.count, by: 5).map {
             Array(peoples[$0..<min($0 + 5, peoples.count)])
@@ -265,15 +266,31 @@ struct MyPeopleSection: View {
     }
 
     var body: some View {
-        let _ = print("📌 MyPeopleSection peoples count: \(peoples.count)")
-        let _ = peoples.forEach { print("\($0.name), position: \($0.position ?? -1)") }
         VStack(spacing: 8) {
             HStack {
                 Text("내 사람들")
                     .font(Font.Pretendard.h1Bold())
                     .foregroundStyle(Color.black)
                 Spacer()
-                Image(systemName: "ellipsis")
+                Button {
+                    showEllipsisOptions = true
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .rotationEffect(.degrees(90))
+                        .font(Font.Pretendard.h2Bold())
+                        .foregroundStyle(Color.black)
+                }
+                .confirmationDialog("옵션 선택", isPresented: $showEllipsisOptions, titleVisibility: .visible) {
+                    Button("사람 추가") {
+                        UserSession.shared.appStep = .registerFriends
+                    }
+                    // TODO: - 순서 편집으로 내 사람들 순서 변경 로직 추가하기.
+//                    Button("순서 편집") {
+//                        // 순서 편집 로직
+//                        print("순서 편집")
+//                    }
+                    Button("취소", role: .cancel) { }
+                }
             }
             .padding(.top)
             .padding(.horizontal, 24)

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -59,6 +59,9 @@ public struct HomeView: View {
                 .frame(maxHeight: .infinity)
             }
         }
+        .onAppear {
+            homeViewModel.loadPeoplesFromUserSession()
+        }
     }
 }
 
@@ -262,6 +265,8 @@ struct MyPeopleSection: View {
     }
 
     var body: some View {
+        let _ = print("📌 MyPeopleSection peoples count: \(peoples.count)")
+        let _ = peoples.forEach { print("\($0.name), position: \($0.position ?? -1)") }
         VStack(spacing: 8) {
             HStack {
                 Text("내 사람들")

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -278,7 +278,7 @@ struct MyPeopleSection: View {
                     // 내 사람들 없는 경우
                     VStack(alignment: .center, spacing: 8) {
                         Button {
-                            // TODO: - 연락처 추가 뷰 연결
+                            UserSession.shared.appStep = .registerFriends
                         } label: {
                             Image(systemName: "plus")
                                 .font(.title)

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -126,6 +126,7 @@ struct ContactFrequencySettingsView: View {
                         }
                         
                     }
+                    UserSession.shared.user?.friends = viewModel.people
                     complete()
                 }
                 label: {

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -6,7 +6,7 @@ struct ContactFrequencySettingsView: View {
     @State private var showFrequencyPicker: Bool = false
     
     let back: () -> Void
-    let complete: () -> Void
+    let complete: ([Friend]) -> Void
 
     var body: some View {
         Spacer()
@@ -123,11 +123,11 @@ struct ContactFrequencySettingsView: View {
                     viewModel.downloadKakaoImageData { friendsWithImages in
                         DispatchQueue.main.async {
                             viewModel.uploadAllFriendsToServer(friendsWithImages)
+//                            viewModel.assignPositionToPeople()
+                            UserSession.shared.user?.friends = viewModel.people
+                            complete(viewModel.people)
                         }
-                        
                     }
-                    UserSession.shared.user?.friends = viewModel.people
-                    complete()
                 }
                 label: {
                     Text("완료")
@@ -310,22 +310,22 @@ struct FrequencyPickerView: View {
     }
 }
 
-#Preview {
-    let viewModel: ContactFrequencySettingsViewModel = {
-        let vm = ContactFrequencySettingsViewModel()
-        vm.people = [
-            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
-            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
-            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none)
-        ]
-        return vm
-    }()
-    ContactFrequencySettingsView(
-        viewModel: viewModel,
-        back: { print("이전") },
-        complete: { print("완료") }
-    )
-}
+//#Preview {
+//    let viewModel: ContactFrequencySettingsViewModel = {
+//        let vm = ContactFrequencySettingsViewModel()
+//        vm.people = [
+//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
+//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
+//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
+//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
+//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
+//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none)
+//        ]
+//        return vm
+//    }()
+//    ContactFrequencySettingsView(
+//        viewModel: viewModel,
+//        back: { print("이전") },
+//        complete: { print("완료") }
+//    )
+//}


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 연락처 추가 후 HomeView에 바로 반영되지 않는 문제 수정
- 내 사람들이 없을 경우 + 버튼을 눌러 프로필을 추가할 수 있도록 연결
- 사람 추가 버튼 삽입 로직 및 레이아웃 조건부 처리 구현
- ellipsis 액션시트 버튼 추가

## 📄 작업 내용 상세 설명
- UserSession.shared.user.friends에 친구 추가 시점에 업데이트
- HomeViewModel에서 peoples를 동기화하도록 loadPeoplesFromUserSession 개선
- HomeView의 star layout에 사람이 5명 미만일 경우 + 버튼이 나타나도록 조건 처리
- + 버튼 탭 시 사람 추가 flow (RegisterFriendsView)로 이동하도록 연결
- ellipsis 버튼 추가 및 액션시트 연결

### 🎯 작업 목적
- 친구를 추가한 뒤 홈 화면에 바로 반영되도록 개선

### 🛠️ 주요 변경 사항
- 파일명 변경: `OldFile.swift` → `NewFile.swift`
- [기타 변경 사항을 추가하세요.]

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [ ] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 현재 추가된 인원 수에 따라 star layout 레이아웃이 바뀌는 로직은 단순한 조건 분기만 되어 있음 → 추후 리팩토링 필요

### ✅ 참고 이슈 및 관련 작업
- https://github.com/SWYP-App-2nd/iOS/issues/20
- https://github.com/SWYP-App-2nd/iOS/issues/19