### PR TITLE
[Feature] 자동로그인 유저 정보 가져오기, 약관 연결

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -45,7 +45,11 @@ let project = Project(
                     "CFBundleShortVersionString": "$(MARKETING_VERSION)",
                     "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
                     "NSContactsUsageDescription": "연락처에서 챙길 사람을 가져오려면\n 기기 설정에서 연락처를 허용해주세요.",
-                    "KAKAO_APP_KEY": "$(KAKAO_APP_KEY)"
+                    "KAKAO_APP_KEY": "$(KAKAO_APP_KEY)",
+                    "DEV_BASE_URL": "$(DEV_BASE_URL)",
+                    "SERVICE_AGREED_TERMS_URL": "$(SERVICE_AGREED_TERMS_URL)",
+                    "PERSONAL_INFO_TERMS_URL": "$(PERSONAL_INFO_TERMS_URL)",
+                    "PRIVACY_POLICY_TERMS_URL": "$(PRIVACY_POLICY_TERMS_URL)"
                 ]
             ),
             sources: [

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -25,7 +25,13 @@ struct PresignedURLResponse: Decodable {
 final class BackEndAuthService {
     static let shared = BackEndAuthService()
 
-    private let baseURL = "https://dev.near.io.kr"
+    private let baseURL: String = {
+        if let host = Bundle.main.infoDictionary?["DEV_BASE_URL"] as? String {
+            return "https://\(host)"
+        } else {
+            return ""
+        }
+    }()
 
     /// 백엔드: 카카오 로그인 처리
     func loginWithKakao(accessToken: String, completion: @escaping (Result<TokenResponse, Error>) -> Void) {
@@ -43,6 +49,7 @@ final class BackEndAuthService {
                     )
                     completion(.success(tokenResponse))
                 case .failure(let error):
+                    print("\(Bundle.main.infoDictionary?["DEV_BASE_URL"] as? String ?? "")")
                     print(
                         "🔴 [BackEndAuthService] 카카오 로그인 실패: \(error.localizedDescription)"
                     )

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -22,6 +22,17 @@ struct PresignedURLResponse: Decodable {
     let preSignedUrl: String
 }
 
+struct MemberMeInfoResponse: Decodable {
+    let memberId: String
+    let username: String
+    let nickname: String
+    let imageUrl: String?
+    let averageRate: Int
+    let isActive: Bool
+    let marketingAgreedAt: String?
+    let providerType: String
+}
+
 final class BackEndAuthService {
     static let shared = BackEndAuthService()
 
@@ -32,6 +43,25 @@ final class BackEndAuthService {
             return ""
         }
     }()
+    
+    /// 백엔드: fetch User Data
+    func fetchMemberInfo(accessToken: String, completion: @escaping (Result<MemberMeInfoResponse, Error>) -> Void) {
+        let url = "\(baseURL)/member/me"
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
+            
+        AF.request(url, method: .get, headers: headers)
+            .validate(statusCode: 200..<300)
+            .responseDecodable(of: MemberMeInfoResponse.self) { response in
+                switch response.result {
+                case .success(let data):
+                    completion(.success(data))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+    }
 
     /// 백엔드: 카카오 로그인 처리
     func loginWithKakao(accessToken: String, completion: @escaping (Result<TokenResponse, Error>) -> Void) {

--- a/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
@@ -37,6 +37,14 @@ class LoginViewModel: ObservableObject {
                     self.isLoading = false
                     switch result {
                     case .success(let tokenResponse):
+                        var user = User(
+                            id: "",
+                            name: "",
+                            friends: [], loginType: .kakao,
+                            serverAccessToken: tokenResponse.accessToken,
+                            serverRefreshToken: tokenResponse.refreshTokenInfo.token
+                        )
+                        
                         // 서버 토큰 저장
                         TokenManager.shared
                             .save(token: tokenResponse.accessToken, for: .server)
@@ -46,15 +54,19 @@ class LoginViewModel: ObservableObject {
                                 for: .server,
                                 isRefresh: true
                             )
-                        // TODO: - id, name 서버에서 받을건지 요청
-                        let user = User(
-                            id: UUID().uuidString,
-                            name: "",
-                            friends: [], loginType: .kakao,
-                            serverAccessToken: tokenResponse.accessToken,
-                            serverRefreshToken: tokenResponse.refreshTokenInfo.token
-                        )
-                        self.updateUserSession(with: user)
+                        
+                        BackEndAuthService.shared
+                            .fetchMemberInfo(accessToken: tokenResponse.accessToken) { result in
+                                switch result {
+                                case .success(let userInfo):
+                                    print("🟢 자동 로그인 성공: \(userInfo.nickname)")
+                                    user.name = userInfo.nickname
+                                    user.id = userInfo.memberId
+                                    self.updateUserSession(with: user)
+                                case .failure(let error):
+                                    print("🔴 자동 로그인 실패: \(error)")
+                                }
+                            }
                     case .failure(let error):
                         self.errorMessage = "서버 로그인 실패: \(error.localizedDescription)"
                     }
@@ -89,6 +101,15 @@ class LoginViewModel: ObservableObject {
                         self.isLoading = false
                         switch result {
                         case .success(let tokenResponse):
+                            
+                            var user = User(
+                                id: "",
+                                name: "",
+                                friends: [], loginType: .apple,
+                                serverAccessToken: tokenResponse.accessToken,
+                                serverRefreshToken: tokenResponse.refreshTokenInfo.token
+                            )
+                            
                             TokenManager.shared
                                 .save(
                                     token: tokenResponse.accessToken,
@@ -100,15 +121,19 @@ class LoginViewModel: ObservableObject {
                                     for: .server,
                                     isRefresh: true
                                 )
-                            // TODO: - id, name 서버에서 받을건지 요청
-                            let user = User(
-                                id: "",
-                                name: "",
-                                friends: [], loginType: .apple,
-                                serverAccessToken: tokenResponse.accessToken,
-                                serverRefreshToken: tokenResponse.refreshTokenInfo.token
-                            )
-                            self.updateUserSession(with: user)
+                            
+                            BackEndAuthService.shared
+                                .fetchMemberInfo(accessToken: tokenResponse.accessToken) { result in
+                                    switch result {
+                                    case .success(let userInfo):
+                                        print("🟢 자동 로그인 성공: \(userInfo.nickname)")
+                                        user.name = userInfo.nickname
+                                        user.id = userInfo.memberId
+                                        self.updateUserSession(with: user)
+                                    case .failure(let error):
+                                        print("🔴 자동 로그인 실패: \(error)")
+                                    }
+                                }
                         case .failure(let error):
                             self.errorMessage = "서버 로그인 실패: \(error.localizedDescription)"
                         }

--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -126,6 +126,7 @@ class RegisterFriendsViewModel: ObservableObject {
             orientation: .auto, // 피커 화면 방향
             enableSearch: true, // 검색 기능 사용 여부
             enableIndex: true, // 인덱스뷰 사용 여부
+            showMyProfile: false, // 내 프로필 표시
             showFavorite: true, // 즐겨찾기 친구 표시 여부
             showPickedFriend: true, // 선택한 친구 표시 여부, 멀티 피커에만 사용 가능
             maxPickableCount: 5, // 선택 가능한 최대 대상 수

--- a/SwypApp2nd/Sources/ViewModels/Login/Terms/TermsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/Terms/TermsViewModel.swift
@@ -22,6 +22,33 @@ final class TermsViewModel: ObservableObject {
         }
     }
     
+    /// 서비스 이용 약관
+    @Published var serviceAgreedTermsURL: String = {
+        if let host = Bundle.main.infoDictionary?["SERVICE_AGREED_TERMS_URL"] as? String {
+            return "https://\(host)"
+        } else {
+            return ""
+        }
+    }()
+    
+    /// 개인 정보 수집 및 이용 약관
+    @Published var personalInfoTermsURL: String = {
+        if let host = Bundle.main.infoDictionary?["PERSONAL_INFO_TERMS_URL"] as? String {
+            return "https://\(host)"
+        } else {
+            return ""
+        }
+    }()
+    
+    /// 개인 정보 처리방침 상세 약관
+    @Published var privacyPolicyTermsURL: String = {
+        if let host = Bundle.main.infoDictionary?["PRIVACY_POLICY_TERMS_URL"] as? String {
+            return "https://\(host)"
+        } else {
+            return ""
+        }
+    }()
+    
     /// 약관 전체 동의 체크 메소드
     func toggleAllAgreed() {
         let shouldAgree = !isAllAgreed

--- a/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
@@ -46,7 +46,7 @@ public struct TermsView: View {
                         title: "[필수] 서비스 이용 약관",
                         isBold: false,
                         showDetail: true,
-                        detailURLString: "https://example.com/") {
+                        detailURLString: viewModel.serviceAgreedTermsURL) {
                             // checkbox closure
                         } onDetailTappedClosure: { title, url in
                             self.selectedAgreement = AgreementDetail(title: title, urlString: url)
@@ -61,7 +61,7 @@ public struct TermsView: View {
                         title: "[필수] 개인정보 수집 및 이용 동의서",
                         isBold: false,
                         showDetail: true,
-                        detailURLString: "https://example.com/") {
+                        detailURLString: viewModel.personalInfoTermsURL) {
                             // checkbox closure
                         } onDetailTappedClosure: { title, url in
                             self.selectedAgreement = AgreementDetail(title: title, urlString: url)
@@ -77,7 +77,7 @@ public struct TermsView: View {
                         title: "[필수] 개인정보 처리방침",
                         isBold: false,
                         showDetail: true,
-                        detailURLString: "https://example.com/") {
+                        detailURLString: viewModel.privacyPolicyTermsURL) {
                             // checkbox closure
                         } onDetailTappedClosure: { title, url in
                             self.selectedAgreement = AgreementDetail(title: title, urlString: url)


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 약관 동의 분기 처리를 config 기반으로 개선하고, 자동 로그인 시 서버 사용자 정보를 동기화하는 로직을 추가했습니다.

## 📄 작업 내용 상세 설명
- UserSession에서 카카오/애플 로그인 시 약관 동의 여부를 각각 UserDefaults 키값 (didAgreeToKakaoTerms, didAgreeToAppleTerms) 기준으로 분기 처리
- 자동 로그인 로직 개선:
    - 서버 accessToken 존재 시 → /member/me API 호출 → 사용자 정보 갱신
    - accessToken 없을 경우 refreshToken으로 재발급 → 이후 사용자 정보 갱신
- UserSession 내 tryAutoLogin, tryKakaoAutoLogin, tryAppleAutoLogin에 유저 정보 fetch 로직 통합
- 서버 응답 실패 시 안전하게 logout() 처리
- 카카오 친구목록 화면 자신 제외 처리

### 🎯 작업 목적
- 자동 로그인 시 사용자 정보를 최신 상태로 유지
- 로그인 시점에 서버에 유효한 유저인지 확인하고, 유효하지 않을 경우 안전하게 로그아웃 처리

### 🛠️ 주요 변경 사항
- 기능 개선: UserSession.swift
    - 약관 분기 처리
    - 자동 로그인 → 서버 사용자 정보 동기화 추가
    - accessToken, refreshToken 유효성 및 fallback 처리 개선
- API 연동: BackEndAuthService.shared.fetchMemberInfo() 호출 위치 통합
- 리팩토링: 기존 tryKakaoAutoLogin, tryAppleAutoLogin 내부 구조 개선

### 📸 스크린샷 (필요시 추가)
<img src="https://github.com/user-attachments/assets/09c61200-3c61-4efe-8d67-ecb90459cfd1" width="300" />
<img src="https://github.com/user-attachments/assets/7a7d30ce-9f5d-4736-b7db-b43b31beb3f7" width="300" />
<img src="https://github.com/user-attachments/assets/639d8991-2dc8-4cfb-a83f-8118681c43a2" width="300" />

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 자동 로그인을 하면 로그인 화면으로 가지 않고 홈화면으로 이동하게 됩니다. 사용자 이름이 잘 나오는지 확인해주세요

### ✅ 참고 이슈 및 관련 작업
https://github.com/SWYP-App-2nd/iOS/issues/7