### PR TITLE
[Feature] My Page 디자인 적용

### DIFF
--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -37,8 +37,13 @@ struct FriendListResponse: Codable, Identifiable {
     let name: String
     let imageUrl: String?
     let fileName: String?
-
+    
     var id: String { friendId }
+}
+
+struct WithdrawRequest: Encodable {
+    let reasonType: String
+    let customReason: String
 }
 
 final class BackEndAuthService {
@@ -114,7 +119,7 @@ final class BackEndAuthService {
                         "🟢 [BackEndAuthService] 애플 로그인 성공 - accessToken: \(tokenResponse.accessToken.prefix(10))..., refreshToken: \(tokenResponse.refreshTokenInfo.token.prefix(10))..."
                     )
                     completion(.success(tokenResponse))
-                case .failure(let error):
+                case .failure(let  error):
                     print(
                         // TODO: - AppleLogin은 실패중...
                         "🔴 [BackEndAuthService] 애플 로그인 실패: \(error.localizedDescription)"
@@ -318,6 +323,34 @@ final class BackEndAuthService {
                     completion(.success(()))
                 case .failure(let error):
                     print("🔴 [BackEndAuthService] 리마인더 전송 실패: \(error.localizedDescription)")
+                    completion(.failure(error))
+            }
+        }
+    }
+    
+    func withdraw(accessToken: String, selectedReason: String, customReason:String, completion: @escaping (Result<Void, Error>) -> Void) {
+        
+        let url = "\(baseURL)/member/withdraw"
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
+        let body = WithdrawRequest(reasonType: selectedReason, customReason: customReason)
+       
+        AF.request(
+            url,
+            method: .delete,
+            parameters: body,
+            encoder: JSONParameterEncoder.default,
+            headers: headers
+        )
+            .validate()
+            .response { response in
+                switch response.result {
+                case .success:
+                    print("🟢 [BackEndAuthService] 탈퇴 전송 성공")
+                    completion(.success(()))
+                case .failure(let error):
+                    print("🔴 [BackEndAuthService] 탈퇴 전송 실패: \(error.localizedDescription)")
                     completion(.failure(error))
                 }
             }

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -119,7 +119,7 @@ final class BackEndAuthService {
                         "🟢 [BackEndAuthService] 애플 로그인 성공 - accessToken: \(tokenResponse.accessToken.prefix(10))..., refreshToken: \(tokenResponse.refreshTokenInfo.token.prefix(10))..."
                     )
                     completion(.success(tokenResponse))
-                case .failure(let  error):
+                case .failure(let error):
                     print(
                         // TODO: - AppleLogin은 실패중...
                         "🔴 [BackEndAuthService] 애플 로그인 실패: \(error.localizedDescription)"

--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -45,7 +45,7 @@ struct UserProfileSectionView: View {
     var profilePic: String?
     
     var body: some View {
-        VStack(spacing: 15) {
+        VStack(spacing: 16) {
             if let urlString = profilePic, let url = URL(string: urlString) {
                 KFImage(url)
                     .resizable()

--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -33,11 +33,10 @@ struct MyProfileView: View {
                 )
             }
             .fullScreenCover(isPresented: $showWithdrawalSheet) {
-                WithdrawalView()
+                WithdrawalView(path: $path)
             }
-            .padding(.horizontal)
-            .navigationBarTitle("MY", displayMode: .inline)
         }
+        .padding(.horizontal, 12)
     }
 }
 
@@ -46,29 +45,21 @@ struct UserProfileSectionView: View {
     var profilePic: String?
     
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 15) {
             if let urlString = profilePic, let url = URL(string: urlString) {
                 KFImage(url)
                     .resizable()
                     .scaledToFill()
-                    .frame(width: 100, height: 100)
+                    .frame(width: 80, height: 80)
                     .clipShape(Circle())
             } else {
-                ZStack {
-                    Circle()
-                        .fill(Color.gray.opacity(0.3))
-                        .frame(width: 100, height: 100)
-                    Image(systemName: "person.fill")
-                        .font(.system(size: 40))
-                        .foregroundColor(.white)
-                }
+                Image("_img_80_user1")
+                    .frame(width: 80, height: 80)
             }
-            
             Text(name)
-                .font(.title3)
-                .fontWeight(.semibold)
+                .font(Font.Pretendard.b1Bold())
         }
-        .padding(.top, 40)
+        .padding(.top,20)
     }
 }
 
@@ -77,15 +68,16 @@ struct AccountSettingSectionView: View {
     
     var body: some View {
         VStack(spacing: 1) {
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 24) {
                 Text("일반")
-                    .font(.title2)
+                    .font(Font.Pretendard.b1Bold())
                     .fontWeight(.bold)
-                    .padding(.top, 10)
+                    .padding(.top, 42)
                     .padding(.horizontal)
                 
                 HStack {
                     Text("연결계정")
+                        .font(Font.Pretendard.b1Medium())
                         .foregroundColor(.black)
                     Spacer()
                     let (loginName, imageName): (String, String) = {
@@ -98,18 +90,11 @@ struct AccountSettingSectionView: View {
                     HStack(spacing: 5) {
                         Text(loginName)
                             .foregroundColor(.gray)
-                        
                         Image(imageName)
-                            .resizable()
-                            .frame(width: 20, height: 20)
                     }
                 }
-                .padding()
-                .background(Color.white)
-                .cornerRadius(8)
                 .padding(.horizontal)
             }
-            .background(Color(.systemGroupedBackground))
         }
     }
 }
@@ -120,8 +105,9 @@ struct NotificationSettingsView: View {
 
     var body: some View {
         Toggle("알림설정", isOn: $viewModel.isNotificationOn)
-            .padding()
-            .background(Color(.systemGray6))
+            .padding(.horizontal)
+            .font(Font.Pretendard.b1Medium())
+            .tint(Color.blue02)
             .onAppear {
                 viewModel.loadInitialState()
             }
@@ -139,9 +125,7 @@ struct NotificationSettingsView: View {
             Button("취소", role: .cancel) { viewModel.showSettingsAlert = false }
         } message: {
             Text("알림 설정을 켜야 \n챙김 알림을 받을 수 있어요.")
-        }
-//        .padding()
-        .background(Color(.systemGray6))
+            }
         }
     }
 
@@ -159,14 +143,15 @@ struct SimpleTermsView: View {
 
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("서비스 약관 안내")
-                .font(.title2)
+        VStack(alignment: .leading, spacing: 14) {
+            Text("서비스 정보")
+                .font(Font.Pretendard.b1Bold())
                 .fontWeight(.bold)
-                .padding(.top, 20)
+                .padding(.top, 42)
+                .padding(.bottom, 14)
                 .padding(.horizontal)
 
-            ForEach(terms) { term in
+        ForEach(Array(terms.enumerated()), id: \.1.id) { index, term in
                 Button {
                     selectedAgreement = term
                 } label: {
@@ -177,17 +162,17 @@ struct SimpleTermsView: View {
                         Spacer()
                         Image(systemName: "chevron.right")
                             .foregroundColor(.gray)
+                            .frame(width: 24, height: 24)
                     }
-                    .padding()
-                    .background(Color.white)
-                    .cornerRadius(8)
                 }
-                .padding(.horizontal)
+                if index < terms.count - 1 {
+                    Divider()
+                        .background(Color.gray02)
+                }
             }
-
-            Spacer()
+            .padding(.horizontal)
         }
-        .background(Color(.systemGroupedBackground))
+        
         .fullScreenCover(item: $selectedAgreement) { agreement in
             NavigationStack {
                 TermsDetailView(
@@ -227,42 +212,89 @@ struct WithdrawalButtonView: View {
                     UserSession.shared.kakaoLogout{ success in
                         if success {
                             path.removeLast()
-                            }
+                        }
                     }
                 }
-                 else {
-                     UserSession.shared.appleLogout{ success in
-                         if success {
-                             path.removeLast()
-                             }
-                     }
+                else {
+                    UserSession.shared.appleLogout{ success in
+                        if success {
+                            path.removeLast()
+                        }
+                    }
                 }
             }) {
                 Text("로그아웃")
+                    .font(Font.Pretendard.b1Bold())
+                    .foregroundStyle(Color.black)
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color.black, lineWidth: 1)
+                            .stroke(Color.gray02, lineWidth: 1)
                     )
             }
             .padding(.horizontal)
-
+            .padding(.top, 42)
+            
             Button(action: {
                 onWithdrawTap()
             }) {
                 Text("탈퇴하기")
-                    .font(.footnote)
-                    .foregroundColor(.gray)
+                    .font(Font.Pretendard.b2Medium())
+                    .underline()
+                    .lineSpacing(4)
+                    .kerning(-0.25) // TODO
+                    .foregroundColor(Color.gray01)
                     .padding(.bottom, 20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
             }
+            .padding(.top, 18)
         }
     }
 }
 
-//
-//struct MyProfileView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MyProfileView()
-//    }
-//}
+struct MyProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            previewForDevice("iPhone 13 mini")
+            previewForDevice("iPhone 16")
+            previewForDevice("iPhone 16 Pro")
+            previewForDevice("iPhone 16 Pro Max")
+        }
+    }
+
+    static func previewForDevice(_ deviceName: String) -> some View {
+
+        let fakeFriends = [
+            Friend(
+                id: UUID(), name: "정종원1", image: nil, imageURL: nil,
+                source: .kakao, frequency: CheckInFrequency.none, remindCategory: .message,
+                nextContactAt: Date(), lastContactAt: Date().addingTimeInterval(-86400),
+                checkRate: 20, position: 0
+            )
+        ]
+
+        UserSession.shared.user = User(
+            id: "preview", name: "프리뷰",
+            friends: fakeFriends,
+            loginType: .kakao,
+            serverAccessToken: "token",
+            serverRefreshToken: "refresh"
+        )
+
+        return MyProfileWrapper()
+            .previewDevice(PreviewDevice(rawValue: deviceName))
+            .previewDisplayName(deviceName)
+    }
+
+
+    struct MyProfileWrapper: View {
+        @State var path: [AppRoute] = [.my]
+
+        var body: some View {
+            MyProfileView(path: $path)
+        }
+    
+    }
+}

--- a/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
+++ b/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
@@ -47,7 +47,7 @@ struct WithdrawalView: View {
                 onCancel: { presentationMode.wrappedValue.dismiss() }
             )
         }
-        .padding()
+        .padding(.horizontal, 24)
 }
 
 struct WithdrawalHeaderView: View {
@@ -191,12 +191,12 @@ struct WithdrawalActionButtonsView: View {
                             .stroke(isValid ? Color.black : Color.gray, lineWidth: 1)
                     )
                     .cornerRadius(10)
-            }
+                }
             .disabled(!isValid)
+            }
         }
     }
 }
-
 
 struct WithdrawalView_Previews: PreviewProvider {
     static var previews: some View {
@@ -241,5 +241,4 @@ struct WithdrawalView_Previews: PreviewProvider {
         }
         
     }
-}
-}
+    }

--- a/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
+++ b/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
@@ -1,10 +1,77 @@
 import SwiftUI
 
 struct WithdrawalView: View {
+    @Binding var path: [AppRoute]
     @Environment(\.presentationMode) var presentationMode
     @State private var selectedReason: String = ""
     @State private var customReason: String = ""
+    @State private var showConfirmAlert = false
     @FocusState private var isCustomReasonFocused: Bool
+    var user = UserSession.shared.user!
+    
+    var isValidCustomReason: Bool {
+        selectedReason != "기타" || (customReason.count >= 1 && customReason.count <= 200)
+    }
+        
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            WithdrawalHeaderView()
+                
+            Text("\(user.name)님, \n떠나는 이유를 알려주시면 \n큰 도움이 될 거예요.")
+                .font(Font.Pretendard.h1Medium(size: 24))
+                .lineSpacing(8)
+                .padding(.top, 42)
+            
+            Text("소중한 의견을 받아 \n더 나은 서비스를 만들어갈게요.")
+                .font(Font.Pretendard.b1Medium())
+                .foregroundColor(.gray)
+                .padding(.bottom, 42)
+            
+            WithdrawalReasonListView(
+                selectedReason: $selectedReason,
+                isCustomReasonFocused: _isCustomReasonFocused
+            )
+            
+            if selectedReason == "기타" {
+                CustomReasonInputView(
+                    customReason: $customReason,
+                    isCustomReasonFocused: _isCustomReasonFocused
+                )
+            }
+            
+            Spacer()
+            
+            WithdrawalActionButtonsView(
+                isValid: isValidCustomReason,
+                onWithdraw: { showConfirmAlert = true },
+                onCancel: { presentationMode.wrappedValue.dismiss() }
+            )
+        }
+        .padding()
+}
+
+struct WithdrawalHeaderView: View {
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        HStack {
+            Text("탈퇴하기")
+                .font(Font.Pretendard.b1Bold())
+            Spacer()
+            Button(action: {
+                presentationMode.wrappedValue.dismiss()
+            }) {
+                Image(systemName: "xmark")
+                    .frame(width: 32, height: 32, alignment: .trailing)
+                    .foregroundColor(Color.black)
+            }
+        }
+    }
+}
+
+struct WithdrawalReasonListView: View {
+    @Binding var selectedReason: String
+    @FocusState var isCustomReasonFocused: Bool
 
     let reasons = [
         "자주 이용하지 않아요",
@@ -14,143 +81,165 @@ struct WithdrawalView: View {
         "기타"
     ]
 
-    var isValidCustomReason: Bool {
-        selectedReason != "기타" || (customReason.count >= 1 && customReason.count <= 200)
+    var body: some View {
+        ForEach(reasons, id: \.self) { reason in
+            HStack {
+                Image(systemName: selectedReason == reason ? "largecircle.fill.circle" : "circle")
+                    .foregroundColor(selectedReason == reason ? Color.blue01 : Color.gray03)
+                Text(reason)
+                Spacer()
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                selectedReason = reason
+                if reason == "기타" {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        isCustomReasonFocused = true
+                    }
+                }
+            }
+        }
     }
+}
+    
+struct CustomReasonInputView: View {
+    @Binding var customReason: String
+    @FocusState var isCustomReasonFocused: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            // 상단 헤더
-            HStack {
-                Text("탈퇴하기")
-                    .font(.headline)
-                Spacer()
-                Button(action: {
-                    presentationMode.wrappedValue.dismiss()
-                }) {
-                    Image(systemName: "xmark")
-                        .foregroundColor(.black)
+        VStack(alignment: .leading, spacing: 4) {
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(
+                        customReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ? Color.gray03 : Color.blue01,
+                        lineWidth: 1
+                    )
+                    .frame(minHeight: 100)
+
+                if customReason.isEmpty {
+                    Text("편하게 의견을 남겨주세요.")
+                        .font(Font.Pretendard.b1Medium())
+                        .foregroundColor(Color.gray02)
+                        .padding(.leading, 14)
+                        .padding(.top, 16)
+                        .zIndex(1)
                 }
-            }
-            
-            Spacer()
-            // TODO 사람 이름 가져오기
-            Text("김민지님, \n떠나는 이유를 알려주시면 \n큰 도움이 될 거예요.")
-                .font(.title3)
-                .fontWeight(.semibold)
 
-            Text("소중한 의견을 받아 \n더 나은 서비스를 만들어갈게요.")
-                .font(.footnote)
-                .foregroundColor(.gray)
+                VStack {
+                    TextEditor(text: Binding(
+                        get: { String(customReason.prefix(200)) },
+                        set: { customReason = String($0.prefix(200)) }
+                    ))
+                    .padding(12)
+                    .frame(minHeight: 100)
+                    .background(Color.clear)
+                    .focused($isCustomReasonFocused)
 
-            // 탈퇴 사유 선택
-            ForEach(reasons, id: \.self) { reason in
-                HStack {
-                    Image(systemName: selectedReason == reason ? "largecircle.fill.circle" : "circle")
-                        .foregroundColor(.black)
-                    Text(reason)
-                    Spacer()
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    selectedReason = reason
-                    if reason == "기타" {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            isCustomReasonFocused = true // 자동 포커스
-                        }
-                    }
-                }
-            }
-
-            if selectedReason == "기타" {
-                VStack(alignment: .leading, spacing: 5) {
-                    ZStack(alignment: .topLeading) {
-                        if customReason.isEmpty {
-                            Text("탈퇴 사유를 적어주세요")
-                                .foregroundColor(.gray)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 10)
-                        }
-
-                        TextEditor(text: Binding(
-                            get: {
-                                String(customReason.prefix(200))
-                            },
-                            set: {
-                                customReason = String($0.prefix(200))
-                            })
-                        )
-                        .frame(minHeight: 100)
-                        .padding(6)
-                        .background(Color(.systemGray6))
-                        .cornerRadius(8)
-                        .focused($isCustomReasonFocused)
-                    }
-
-                    // 글자 수 표시
                     HStack {
                         Spacer()
-                        Text("\(customReason.count)/200자")
+                        Text("\(customReason.count)/200")
                             .font(.caption)
                             .foregroundColor(customReason.count >= 200 ? .red : .gray)
-                    }
-
-                    // 벨리데이션 문구
-                    if customReason.count < 1 {
-                        Text("1글자 이상 입력해주세요.")
-                            .foregroundColor(.red)
-                            .font(.caption)
-                    } else if customReason.count >= 200 {
-                        Text("200자 이상 작성할 수 없어요.")
-                            .foregroundColor(.red)
-                            .font(.caption)
+                            .padding(.trailing, 12)
+                            .padding(.bottom, 4)
                     }
                 }
             }
 
-            Spacer()
-
-            // 버튼 영역
-            HStack {
-                Button(action: {
-                    presentationMode.wrappedValue.dismiss()
-                }) {
-                    Text("더 써볼래요")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.black))
-                }
-
-                Button(action: {
-                    submitWithdrawal()
-                }) {
-                    Text("탈퇴하기")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(isValidCustomReason ? Color.black : Color.gray)
-                        .foregroundColor(.white)
-                        .cornerRadius(10)
-                }
-                .disabled(!isValidCustomReason)
+            if customReason.count < 1 {
+                Text("1글자 이상 입력해주세요.")
+                    .foregroundColor(.red)
+                    .font(.caption)
+            } else if customReason.count >= 200 {
+                Text("200자 이상 작성할 수 없어요.")
+                    .foregroundColor(.red)
+                    .font(.caption)
             }
         }
-        .padding()
-    }
-
-    private func submitWithdrawal() {
-        let reason = selectedReason == "기타" ? customReason : selectedReason
-        guard !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            print("탈퇴 사유 입력 필요")
-            return
-        }
-
-        print("탈퇴 사유:", reason)
-        // 실제 탈퇴 처리 로직
     }
 }
 
+struct WithdrawalActionButtonsView: View {
+    var isValid: Bool
+    var onWithdraw: () -> Void
+    var onCancel: () -> Void
+
+    
+    var body: some View {
+        HStack {
+            Button(action: onCancel) {
+                Text("그만두기")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .font(Font.Pretendard.b1Bold())
+                    .foregroundColor(.white)
+                    .background(Color.blue01)
+                    .cornerRadius(10)
+            }
+
+            Button(action: onWithdraw) {
+                Text("탈퇴하기")
+                    .font(Font.Pretendard.b1Bold())
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.clear)
+                    .foregroundColor(isValid ? Color.black : Color.gray)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(isValid ? Color.black : Color.gray, lineWidth: 1)
+                    )
+                    .cornerRadius(10)
+            }
+            .disabled(!isValid)
+        }
+    }
+}
+
+
 struct WithdrawalView_Previews: PreviewProvider {
     static var previews: some View {
-        WithdrawalView()
+        Group {
+            previewForDevice("iPhone 13 mini")
+            previewForDevice("iPhone 16")
+            previewForDevice("iPhone 16 Pro")
+            previewForDevice("iPhone 16 Pro Max")
+        }
     }
+    
+    static func previewForDevice(_ deviceName: String) -> some View {
+        
+        let fakeFriends = [
+            Friend(
+                id: UUID(), name: "정종원1", image: nil, imageURL: nil,
+                source: .kakao, frequency: CheckInFrequency.none, remindCategory: .message,
+                nextContactAt: Date(), lastContactAt: Date().addingTimeInterval(-86400),
+                checkRate: 20, position: 0
+            )
+        ]
+        
+        UserSession.shared.user = User(
+            id: "preview", name: "프리뷰",
+            friends: fakeFriends,
+            loginType: .kakao,
+            serverAccessToken: "token",
+            serverRefreshToken: "refresh"
+        )
+        
+        return MyProfileWrapper()
+            .previewDevice(PreviewDevice(rawValue: deviceName))
+            .previewDisplayName(deviceName)
+    }
+    
+    
+    struct MyProfileWrapper: View {
+        @State var path: [AppRoute] = [.my]
+        
+        var body: some View {
+            WithdrawalView(path: $path)
+        }
+        
+    }
+}
 }


### PR DESCRIPTION
## ✨ 변경 사항 요약
- My Page 디자인 적용

## 📄 작업 내용 상세 설명
-  피그마 디자인에 따라 유저 프로필 상세 + 탈퇴뷰 디자인 적용하였습니다.

### 🎯 작업 목적
-  피그마 디자인에 따라 디자인 적용하였습니다.

### 🛠️ 주요 변경 사항

### 📸 스크린샷 (필요시 추가)
![ScreenRecording2025-04-18at2 51 28AM-ezgif com-resize](https://github.com/user-attachments/assets/cf03939f-dcb7-47dc-b167-13d96406e1ec)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항

** 아니 왜 탈퇴 기능 추가가 딸려 들어갔을까요?? 난 여기에 커밋한 적이 읎는데1!** 흠 그와중에 backendauth파일은 또 안왔어요;; 
commit 9b01185e711a61d25dcada7806a8c2c6aa7faa83 (HEAD -> feature/mypage-design, origin/feature/mypage-design)
Author: Sharon Kang <kang26d@mtholyoke.edu>
Date:   Fri Apr 18 02:49:27 2025 -0700

    feat: 마이뷰랑 통일해서 패딩 추가

commit 5c56fababe34c7b5990113ce8e702ce7a8e8dead
Author: Sharon Kang <kang26d@mtholyoke.edu>
Date:   Fri Apr 18 02:41:42 2025 -0700

    feat: 마이 프로필 상세 디자인 적용

commit 845c18828081912142c7acdc0ba80ed2c07c961a (origin/feature/withdraw, feature/withdraw)
Author: Sharon Kang <kang26d@mtholyoke.edu>
Date:   Fri Apr 18 02:37:57 2025 -0700

    feat: 탈퇴 기능 추가
### ✅ 참고 이슈 및 관련 작업