### PR TITLE
[Feature] 탈퇴 기능 뷰와 연결, 뷰모델로 함수 넘김, 코드 리팩토링 및 수정

### DIFF
--- a/SwypApp2nd/Sources/ViewModels/My/MyViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/My/MyViewModel.swift
@@ -2,8 +2,15 @@ import SwiftUI
 import Combine
 
 class MyViewModel: ObservableObject {
+    
     @Published var isNotificationOn: Bool = UserDefaults.standard.bool(forKey: "isNotificationOn")
     @Published var showSettingsAlert: Bool = false
+    @Published var selectedReason: String = ""
+    @Published var customReason: String = ""
+    @Published var showConfirmAlert: Bool = false
+    var isValidCustomReason: Bool {
+            selectedReason != "기타" || (customReason.count >= 1 && customReason.count <= 200)
+        }
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -50,5 +57,14 @@ class MyViewModel: ObservableObject {
                     break
                 }
             }
+    }
+    
+    func submitWithdrawal(loginType: LoginType, completion: @escaping (Bool) -> Void) {
+        
+        UserSession.shared.withdraw(loginType: loginType, selectedReason: selectedReason, customReason: customReason) { success in
+            DispatchQueue.main.async {
+                completion(success)
+            }
+        }
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 탈퇴 로직 뷰 연결하였습니다

## 📄 작업 내용 상세 설명
- 백엔드 구현된 걸 뷰에 연결하고 원래 뷰에 있던 함수를 뷰모델로 이전하였습니다.

### 🎯 작업 목적
- MVVM 따르기, 구현만 되어 있었던 기능을 뷰와 연결하여 사용자가 탈퇴할 수 있도록 하기

### 🛠️ 주요 변경 사항
- 이제 유저가 탈퇴할 수 있습니다. 탈퇴 시 로그인 화면으로 이동함과 동시에 appRoute는 초기화 됩니다.

### 📸 스크린샷 (필요시 추가)
![ScreenRecording2025-04-18at9 24 03PM-ezgif com-resize](https://github.com/user-attachments/assets/6c0bb496-e0a0-430d-964a-cf00aa385b99)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- [리뷰어가 참고해야 할 내용이나 주의할 점을 적어주세요.]

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #이슈번호
- 관련 PR: #PR번호