### PR TITLE
[Feature] 친구 상세 정보 API 연동

### DIFF
--- a/SwypApp2nd/Sources/Common/Date+Extension.swift
+++ b/SwypApp2nd/Sources/Common/Date+Extension.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension Date {
+    /// 주기 설정의 다음주기 M/d EEE
     func nextCheckInDate(for frequency: CheckInFrequency) -> String {
         let calendar = Calendar.current
         var nextDate: Date?
@@ -24,6 +25,34 @@ extension Date {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.dateFormat = "M/d EEE"
+
+        return formatter.string(from: date)
+    }
+    
+    /// 주기 설정의 다음주기의 요일 반환 EEEE
+    func nextCheckInDateDayOfTheWeek(for frequency: CheckInFrequency) -> String {
+        let calendar = Calendar.current
+        var nextDate: Date?
+
+        switch frequency {
+        case .daily:
+            nextDate = calendar.date(byAdding: .day, value: 1, to: self)
+        case .weekly:
+            nextDate = calendar.date(byAdding: .weekOfYear, value: 1, to: self)
+        case .biweekly:
+            nextDate = calendar.date(byAdding: .weekOfYear, value: 2, to: self)
+        case .monthly:
+            nextDate = calendar.date(byAdding: .month, value: 1, to: self)
+        case .semiAnnually:
+            nextDate = calendar.date(byAdding: .month, value: 6, to: self)
+        default:
+            return "-"
+        }
+
+        guard let date = nextDate else { return "-" }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "EEEE"
 
         return formatter.string(from: date)
     }

--- a/SwypApp2nd/Sources/Common/String+Extension.swift
+++ b/SwypApp2nd/Sources/Common/String+Extension.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension String {
+    func toDate(format: String = "yyyy-MM-dd") -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = format
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.date(from: self)
+    }
+}

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -1,6 +1,7 @@
 import Alamofire
 import Foundation
 
+// MARK: - 서버 토큰 관리
 struct TokenResponse: Decodable {
     let accessToken: String
     let refreshTokenInfo: RefreshTokenInfo
@@ -11,6 +12,7 @@ struct RefreshTokenInfo: Decodable {
     let expiresAt: String
 }
 
+// MARK: - PreSignedURL
 struct PresignedURLRequest: Encodable {
     let fileName: String
     let contentType: String
@@ -22,6 +24,7 @@ struct PresignedURLResponse: Decodable {
     let preSignedUrl: String
 }
 
+// MARK: - 엑세스 토큰으로 회원 정보 조회
 struct MemberMeInfoResponse: Decodable {
     let memberId: String
     let username: String
@@ -31,6 +34,7 @@ struct MemberMeInfoResponse: Decodable {
     let providerType: String
 }
 
+// MARK: - 친구 리스트 조회
 struct FriendListResponse: Codable, Identifiable {
     let friendId: String
     let position: Int
@@ -41,31 +45,59 @@ struct FriendListResponse: Codable, Identifiable {
     var id: String { friendId }
 }
 
-struct FriendDetailResponse: Codable {
-    // TODO: - 받을 데이터 정의
-    let friendId: String
-    let name: String
-    let imageUrl: String?
-    let source: String
-    let frequency: String?
-    let phoneNumber: String?
-    let relationship: String?
-    let birthDay: String?
-    let anniversaryTitle: String?
-    let anniversaryDate: String?
-    let memo: String?
-    let nextContactAt: String?
-    let lastContactAt: String?
-    let checkRate: Int?
-    let position: Int?
-    let fileName: String?
-}
-
+// MARK: - 회원 탈퇴
 struct WithdrawRequest: Encodable {
     let reasonType: String
     let customReason: String
 }
 
+// MARK: - 친구 상세 정보 조회
+struct FriendDetail {
+    let friendId: String
+    let imageUrl: String?
+    let relation: String?
+    let contactFrequency: CheckInFrequency?
+    let birthDay: String?
+    let anniversaryList: [AnniversaryModel]?
+    let memo: String?
+    let phone: String?
+    
+    struct AnniversaryList {
+        let id : String
+        let title: String
+        let date: String
+    }
+    
+    struct ContactFrequency {
+        let contactWeek : String
+        let dayOfWeek : String
+    }
+}
+
+struct FriendDetailResponse: Codable {
+    let friendId: String
+    let imageUrl: String?
+    let relation: String?
+    let name: String
+    let contactFrequency: FriendDetailResponse.ContactFrequency?
+    let birthday: String?
+    let anniversaryList: [FriendDetailResponse.AnniversaryResponse]?
+    let memo: String?
+    let phone: String?
+    
+    struct ContactFrequency: Codable {
+        let contactWeek: String
+        let dayOfWeek: String
+    }
+
+    struct AnniversaryResponse: Codable {
+        let id: Int
+        let title: String
+        let date: String
+    }
+}
+
+// MARK: - 서버 통신 로직
 final class BackEndAuthService {
     static let shared = BackEndAuthService()
 
@@ -398,74 +430,60 @@ final class BackEndAuthService {
     }
     
     /// 백엔드: 친구별 상세정보 조회
-    func getFriendDetail(friendId: UUID, accessToken: String, completion: @escaping (Result<Friend, Error>) -> Void) {
+    func getFriendDetail(friendId: UUID, accessToken: String, completion: @escaping (Result<FriendDetail, Error>) -> Void) {
         // TODO: 서버 API 명세 나오면 실제 요청 구현
         
         print("🟡 [BackEndAuthService] 친구 상세정보 조회 요청됨 - friendId: \(friendId)")
         
-        let url = "\(baseURL)/friend/detail"
-        let params: Parameters = [ "friend-id": friendId.uuidString]
+        let url = "\(baseURL)/friend/\(friendId.uuidString)"
         let headers: HTTPHeaders = [
             "Authorization": "Bearer \(accessToken)"
         ]
         
-//        AF.request(url, method: .get, parameters: params, headers: headers)
-//            .validate(statusCode: 200..<300)
-//            .responseDecodable(of: [FriendListResponse].self) { response in
-//                switch response.result {
-//                case .success(let friend):
-//                    print("🟢 [BackEndAuthService] 친구별 상세정보 조회 성공 ")
-//                    Friend(
-//                        id: friend.id
-//                        name: friend.name,
-//                        image: nil,
-//                        imageURL: friend.imageUrl,
-//                        source: ContactSource(rawValue: friend.source) ?? .kakao,
-//                        frequency: CheckInFrequency(
-//                            rawValue: frequency ?? ""
-//                        ) ?? .none,
-//                        phoneNumber: friend.phoneNumber,
-//                        relationship: friend.relationship,
-//                        birthDay: friend.birthDay?.toDate(),
-//                        anniversary: AnniversaryModel(
-//                            title: anniversaryTitle,
-//                            Date: anniversaryDate?.toDate()
-//                        ),
-//                        memo: friend.memo,
-//                        nextContactAt: nextContactAt?.toDate(),
-//                        lastContactAt: lastContactAt?.toDate(),
-//                        checkRate: checkRate,
-//                        position: position,
-//                        fileName: fileName
-//                    )
-//                    completion(<#Friend#>)
-//                case .failure(let error):
-//                    print("🔴 [BackEndAuthService] 친구별 상세정보 조회 실패: \(error.localizedDescription)")
-//                    completion(.failure(<#any Error#>))
-//                }
-//            }
-        
-        let mockFriend = Friend(
-            id: friendId,
-            name: "임시 친구",
-            image: nil,
-            imageURL: nil,
-            source: .kakao,
-            frequency: .monthly,
-            phoneNumber: "010-1234-5678",
-            relationship: "동료",
-            birthDay: Date(),
-            anniversary: AnniversaryModel(title: "결혼기념일", Date: Date()),
-            memo: "테스트 메모",
-            nextContactAt: Date().addingTimeInterval(86400 * 30),
-            lastContactAt: Date().addingTimeInterval(-86400 * 10),
-            checkRate: 75,
-            position: 0,
-            fileName: "\(friendId).jpg"
-        )
-            
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            completion(.success(mockFriend))
-        }
+        AF.request(url, method: .get, headers: headers)
+            .validate(statusCode: 200..<300)
+            .responseDecodable(of: FriendDetailResponse.self) { response in
+                switch response.result {
+                case .success(let detail):
+                    print(
+                        "🟢 [BackEndAuthService] 친구별 상세정보 조회 성공 - \(detail.name)"
+                    )
+                    
+                    do {
+                        let encoder = JSONEncoder()
+                        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                        let jsonData = try encoder.encode(detail)
+                        if let jsonString = String(
+                            data: jsonData,
+                            encoding: .utf8
+                        ) {
+                            print("🟡 [getFriendDetail] 서버 응답 JSON:\n\(jsonString)")
+                        }
+                    } catch {
+                        print("🔴 [getFriendDetail] JSON 인코딩 실패: \(error)")
+                    }
+                        
+                    let friendDetail = FriendDetail(
+                        friendId: detail.friendId,
+                        imageUrl: detail.imageUrl,
+                        relation: detail.relation,
+                        contactFrequency: CheckInFrequency(from: detail.contactFrequency),
+                        birthDay: detail.birthday,
+                        anniversaryList: detail.anniversaryList?.compactMap { $0 }.map {
+                            AnniversaryModel(title: $0.title, Date: $0.date.toDate())
+                        },
+                        memo: detail.memo,
+                        phone: detail.phone
+                    )
+                    completion(.success(friendDetail))
+                case .failure(let error):
+                    print(
+                        "🔴 [BackEndAuthService] 친구별 상세정보 조회 실패: \(error.localizedDescription)"
+                    )
+                    completion(.failure(error))
+                }
+            }
     }
 }
+
+

--- a/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
@@ -7,16 +7,17 @@ class HomeViewModel: ObservableObject {
     @Published var allFriends: [Friend] = []
     /// 이번달 챙길 사람
     @Published var thisMonthFriends: [Friend] = []
+    private var cancellables = Set<AnyCancellable>()
+
     
-//    init() {
-//        loadPeoplesFromUserSession()
-//    }
-//
-//    func loadPeoplesFromUserSession() {
-//        DispatchQueue.main.async {
-//            self.peoples = UserSession.shared.user?.friends ?? []
-//        }
-//    }
+    init() {
+        UserSession.shared.$user
+            .compactMap { $0?.friends }
+            .sink { [weak self] friends in
+                self?.allFriends = friends
+            }
+            .store(in: &cancellables)
+    }
     
     func fetchAndSetImage(for friend: Friend, accessToken: String, completion: @escaping (UIImage?) -> Void) {
         guard let fileName = friend.fileName else {

--- a/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
@@ -16,7 +16,26 @@ class ProfileDetailViewModel: ObservableObject {
             switch result {
             case .success(let friendDetail):
                 DispatchQueue.main.async {
-                    self.people = friendDetail
+                    print("self.people.id.uuidString = \(self.people.id.uuidString)")
+                    print("friendDetail.friendId = \(friendDetail.friendId)")
+                    
+                    if self.people.id.uuidString.lowercased() == friendDetail.friendId {
+                        self.people.imageURL = friendDetail.imageUrl
+                        self.people.relationship = friendDetail.relation
+                        self.people.frequency = friendDetail.contactFrequency
+                        self.people.birthDay = friendDetail.birthDay?.toDate()
+                        self.people.anniversary = friendDetail.anniversaryList?.first
+                            .flatMap {
+                                AnniversaryModel(
+                                    title: $0.title,
+                                    Date: $0.Date
+                                )
+                            }
+                        self.people.memo = friendDetail.memo
+                        self.people.phoneNumber = friendDetail.phone
+                        print("🟢 [ProfileDetailViewModel] people 업데이트 성공 : \(String(describing: self.people.phoneNumber))")
+                    }
+                    
                 }
             case .failure(let error):
                 print("🔴 [ProfileDetailViewModel] 친구 상세 정보 가져오기 실패: \(error)")

--- a/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
@@ -2,17 +2,6 @@ import Foundation
 import Combine
 import UIKit
 
-enum CheckInFrequency: String, CaseIterable, Identifiable, Codable {
-    case none = "주기 선택"
-    case daily = "매일"
-    case weekly = "매주"
-    case biweekly = "2주"
-    case monthly = "매달"
-    case semiAnnually = "6개월"
-    
-    var id: String { rawValue }
-}
-
 class ContactFrequencySettingsViewModel: ObservableObject {
     @Published var people: [Friend] = []
     @Published var isUnified: Bool = false

--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -61,8 +61,10 @@ class RegisterFriendsViewModel: ObservableObject {
             let birthDay = $0.birthday?.date
             let anniversaryDay = $0.dates.first?.value as? Date
             let anniversaryDayTitle = $0.dates.first?.label
-            let relationship = $0.contactRelations.first?.value
+            let relationship = $0.contactRelations.first?.label
+            
             let phoneNumber =  $0.phoneNumbers.first?.value.stringValue
+//            let memo = $0.note
             return Friend(
                         id: UUID(),
                         name: name,
@@ -72,10 +74,12 @@ class RegisterFriendsViewModel: ObservableObject {
                         frequency: CheckInFrequency.none,
                         remindCategory: nil,
                         phoneNumber: phoneNumber,
+                        relationship: relationship,
                         birthDay: birthDay,
                         anniversary: AnniversaryModel(
                             title: anniversaryDayTitle ?? nil,
                             Date: anniversaryDay ?? nil),
+//                        memo: memo,
                         nextContactAt: nil,
                         lastContactAt: nil,
                         checkRate: nil,

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
@@ -102,18 +102,34 @@ private struct ProfileHeader: View {
     let people: Friend
     @State private var showActionSheet = false
     @State private var isEditing = false
+    
+    var emojiImageName: String {
+        guard let rate = people.checkRate else {
+            return "icon_visual_24_emoji_0"
+        }
+        switch rate {
+        case 0...30: return "icon_visual_24_emoji_0"
+        case 31...60: return "icon_visual_24_emoji_50"
+        default: return "icon_visual_24_emoji_100"
+        }
+    }
 
     var body: some View {
         HStack(spacing: 16) {
             ZStack(alignment: .topTrailing) {
-                // TODO: - Friend의 PresignedURL 사용 Get
-                Image(systemName: "person.crop.circle.fill")
-                    .resizable()
-                    .frame(width: 80, height: 80)
-                    .foregroundColor(.gray.opacity(0.3))
+                if let image = people.image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .clipShape(Circle())
+                        .frame(width: 80, height: 80)
+                } else {
+                    Image(systemName: "person.crop.circle.fill")
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                        .foregroundColor(.gray.opacity(0.3))
+                }
                 
-                // TODO: - Friend의 checkRate
-                Image("icon_visual_24_emoji_100")
+                Image(emojiImageName)
                     .frame(width: 24, height: 24)
                     .offset(x: 0, y: -5)
             }

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -225,16 +225,15 @@ struct FrequencyPickerView: View {
             
             if let selected = tempSelected {
                 let today = Date()
-                let weekday = today.weekdayKorean()
                 let nextDate = today.nextCheckInDate(for: selected)
-                
+                let nextDateDayOfTheWeek = today.nextCheckInDateDayOfTheWeek(for: selected)
                 
                 HStack {
-                    Text("매주 ")
+                    Text("\(selected.rawValue) ")
                         .font(.body)
                         .foregroundColor(.gray02)
 
-                    Text(weekday)
+                    Text(nextDateDayOfTheWeek)
                         .font(.body)
                         .foregroundColor(.blue01)
 


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 친구 상세 정보 조회 API 연동 및 화면 데이터 적용
- CheckInFrequency 관련 로직 위치 리팩토링
- 주기 설정 바텀시트 요일 표시 버그 수정
- 연락처 추가 후 홈에 반영되지 않던 현상 해결

## 📄 작업 내용 상세 설명
- GET /friend/{friendId} API 연동 및 ProfileDetailViewModel에서 데이터 적용
- 기존 CheckInFrequency enum을 Friend.swift로 이동하여 도메인 구조 개선
- ContactFrequencySettingsView에서 주기 설정 시 표시되는 요일 포맷 문제 수정
- 연락처를 추가한 후 홈 화면에 바로 반영되지 않던 이슈 해결

### 🎯 작업 목적
- 친구 상세 조회 API 연동을 통한 상세 화면 구현
- 신규 연락처 등록 흐름의 UX 버그 해결

### 🛠️ 주요 변경 사항
- 파일 이동: CheckInFrequency → Friend.swift

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 현재 anniversary 데이터는 리스트 중 첫 번째만 UI에 반영되고 있습니다.