### PR TITLE
[FIX] 연락처 등록후 홈화면 업데이트 이슈 해결

### DIFF
--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -62,14 +62,14 @@ public struct ContentView: View {
                 }, complete: { updatedPeoples in
                     DispatchQueue.main.async {
                         print("🟢 [ContactFrequencySettingsView] 전달받은 people: \(updatedPeoples.map { $0.name })")
-//                        homeViewModel.peoples = updatedPeoples
-                        UserSession.shared.user?.friends = updatedPeoples
+                        registerFriendsViewModel.selectedContacts.removeAll()
+                        contactFrequencyViewModel.people.removeAll()
+                        homeViewModel.loadFriendList()
                         userSession.appStep = .home
                     }
                 })
                 
             case .home:
-                //                HomeView(homeViewModel: homeViewModel, notificationViewModel: notificationViewModel, path: )
                 NavigationStack(path: $path) {
                     HomeView(homeViewModel: homeViewModel, notificationViewModel: notificationViewModel, path: $path)
                         .transition(.move(edge: .leading))

--- a/SwypApp2nd/Sources/Models/Friend.swift
+++ b/SwypApp2nd/Sources/Models/Friend.swift
@@ -113,6 +113,7 @@ extension Friend {
             else { return nil }
 
             let formatted = date.formattedYYYYMMDD()
+            // TODO: - 기념일 Array로 변경시 추후 수정 필요
             return AnniversaryDTO(title: title, date: formatted)
         }()
         
@@ -130,7 +131,7 @@ extension Friend {
             anniversary: anniversaryDTO,
             birthDay: birthDayString,
             relation: mappedRelation(from: relationship),
-//            memo: memo,
+            memo: memo,
             phone: phoneNumber
         )
     }
@@ -160,6 +161,15 @@ extension Friend {
 }
 
 extension ContactSource {
+    init(serverValue: String) {
+        switch serverValue.uppercased() {
+        case "KAKAO": self = .kakao
+        case "APPLE": self = .phone
+        default:
+            print("🔴 [ContactSource] 알 수 없는 값 '\(serverValue)', 기본값 .phone 사용")
+            self = .phone
+        }
+    }
     func toServerValue() -> String? {
         switch self {
         case .phone: return "APPLE"
@@ -219,7 +229,7 @@ struct FriendInitDTO: Codable {
     let anniversary: AnniversaryDTO?
     let birthDay: String?
     let relation: String?
-//    let memo: String?
+    let memo: String?
     let phone: String?
 }
 
@@ -252,8 +262,14 @@ struct FriendWithUploadURL: Codable {
     let phone: String?
     let nextContactAt: String?
     let preSignedImageUrl: String?
-    let anniversary: AnniversaryDTO?
+    let anniversary: FriendInitResponseAnniversary?
     let fileName: String?
+}
+
+struct FriendInitResponseAnniversary: Codable {
+    let id: Int
+    let title: String
+    let date: String
 }
 
 extension Friend {

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -40,6 +40,7 @@ struct FriendListResponse: Codable, Identifiable {
     let position: Int
     let name: String
     let imageUrl: String?
+    let source: String?
     let fileName: String?
     
     var id: String { friendId }

--- a/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/ContactFrequencySettings/ContactFrequencySettingsViewModel.swift
@@ -91,7 +91,7 @@ class ContactFrequencySettingsViewModel: ObservableObject {
         }
     }
     
-    func uploadAllFriendsToServer(_ friends: [Friend]) {
+    func uploadAllFriendsToServer(_ friends: [Friend], completion: @escaping () -> Void) {
         guard let accessToken = UserSession.shared.user?.serverAccessToken else { return }
         
         BackEndAuthService.shared.sendInitialFriends(friends: friends, accessToken: accessToken) { result in
@@ -145,6 +145,7 @@ class ContactFrequencySettingsViewModel: ObservableObject {
                         }
                     }
                 }
+                completion()
             case .failure(let error):
                 print("🔴 [ContactFrequencySettingsViewModel] 친구 등록 실패: \(error)")
             }

--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -59,12 +59,17 @@ class RegisterFriendsViewModel: ObservableObject {
             let name = $0.familyName + $0.givenName
             let image = $0.thumbnailImageData.flatMap { UIImage(data: $0) }
             let birthDay = $0.birthday?.date
-            let anniversaryDay = $0.dates.first?.value as? Date
+            let anniversaryDateComponents = $0.dates.first?.value as? DateComponents
+            let anniversaryDay = anniversaryDateComponents?.date
             let anniversaryDayTitle = $0.dates.first?.label
+            let anniversary: AnniversaryModel? = {
+                guard let date = anniversaryDay else { return nil }
+                return AnniversaryModel(title: anniversaryDayTitle, Date: date)
+            }()
             let relationship = $0.contactRelations.first?.label
             
             let phoneNumber =  $0.phoneNumbers.first?.value.stringValue
-//            let memo = $0.note
+            let memo = $0.note
             return Friend(
                         id: UUID(),
                         name: name,
@@ -76,10 +81,8 @@ class RegisterFriendsViewModel: ObservableObject {
                         phoneNumber: phoneNumber,
                         relationship: relationship,
                         birthDay: birthDay,
-                        anniversary: AnniversaryModel(
-                            title: anniversaryDayTitle ?? nil,
-                            Date: anniversaryDay ?? nil),
-//                        memo: memo,
+                        anniversary: anniversary,
+                        memo: memo,
                         nextContactAt: nil,
                         lastContactAt: nil,
                         checkRate: nil,

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -1,9 +1,5 @@
 import SwiftUI
 
-// TODO: - 로그아웃 버튼 이동시 삭제.
-import KakaoSDKUser
-import AuthenticationServices
-
 public struct HomeView: View {
 
     @ObservedObject var homeViewModel: HomeViewModel
@@ -17,15 +13,6 @@ public struct HomeView: View {
     
     public var body: some View {
         VStack(spacing: 24) {
-//            // MARK: - Test
-//            ForEach(notificationViewModel.reminders, id: \.self) { reminder in
-//            }
-//                
-//            Button(action: {
-//                notificationViewModel.deleteAllReminders()
-//            }) {
-//                Label("전체 삭제하기", systemImage: "trash")
-//            }
                     
             ZStack(alignment: .top) {
                 Image("img_bg")
@@ -79,7 +66,6 @@ struct CustomNavigationBar: View {
             HStack {
                 Spacer()
                 Button{
-                    // TODO: - MyPage 연결
                     onTapMy()
                 } label: {
                     Text("My")
@@ -87,7 +73,6 @@ struct CustomNavigationBar: View {
                         .foregroundStyle(Color.white)
                 }
                 Button {
-                    // TODO: - Notification 연결
                     onTapBell()
                 } label: {
                     if badgeCount > 0 {

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -127,11 +127,10 @@ struct ContactFrequencySettingsView: View {
                     // 카카오는 이미지 저장 후 BackEnd 서버에 전송
                     viewModel.downloadKakaoImageData { friendsWithImages in
                         DispatchQueue.main.async {
-                            viewModel.uploadAllFriendsToServer(viewModel.people)
-                            UserSession.shared.user?.friends = viewModel.people
-                            viewModel.people = []
-                            // TODO: - Complete로 people 안넘기는 Test 필요
-                            complete(viewModel.people)
+                            viewModel.uploadAllFriendsToServer(viewModel.people) {
+                                UserSession.shared.user?.friends = viewModel.people
+                                complete(viewModel.people)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 연락처 등록 후 이미지가 적용되지 않던 문제 해결
- Apple 연락처 기념일 정보가 누락되던 이슈 수정
- 서버 응답값에서 source를 .kakao / .apple로 정확히 매핑
- 친구 초기 등록 시 서버로부터 반환받은 friendId, fileName을 반영하도록 개선

## 📄 작업 내용 상세 설명
- ContactFrequencySettingsViewModel 내 uploadAllFriendsToServer에서 completion 클로저 추가 → 서버 응답 이후 이미지 업로드가 끝난 뒤 UserSession의 user.friends를 갱신하도록 처리
- HomeViewModel에서 source == "KAKAO" → .kakao, "APPLE" → .apple 로 매핑 
- RegisterFriendsViewModel에서 Apple 연락처 기념일 파싱 로직을 개선

### 🎯 작업 목적
- 연락처 추가 후 홈화면에서 친구 이미지가 제대로 보이지 않던 문제 해결
- Apple 연락처 기념일 정보를 API 요청에 누락 없이 포함

### 🛠️ 주요 변경 사항
- ContactFrequencySettingsViewModel의 uploadAllFriendsToServer 함수 내부 개선 (completion 클로저 추가)
- Friend의 source를 문자열에서 enum으로 매핑 처리
- RegisterFriendsViewModel의 연락처 기념일 추출 로직 수정

### 📸 스크린샷 (필요시 추가)

https://github.com/user-attachments/assets/019cf5d6-f41a-491d-b9d3-b2015562989b

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)