### PR TITLE
[Feature] 알림 디버깅 - 1분 뒤 오게 설정

### DIFF
--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -15,7 +15,6 @@ enum AppStep {
 enum AppRoute: Hashable {
     case inbox
     case my
-    case person(PersonEntity)
     case personDetail(Friend)
 }
 
@@ -42,7 +41,7 @@ public struct ContentView: View {
     }
 
     public var body: some View {
-        Group {
+        VStack {
             switch userSession.appStep {
             case .login, .terms:
                 LoginView(loginViewModel: loginViewModel)
@@ -76,11 +75,7 @@ public struct ContentView: View {
                         .navigationDestination(for: AppRoute.self) { route in
                             switch route {
                             case .inbox:
-                                NotificationInboxView(path: $path)
-//                            case .person(let person):
-//                                ProfileDetailView(person: person)
-                            case .person(_):
-                                NotificationInboxView(path: $path)
+                                NotificationInboxView(path: $path, notificationViewModel: notificationViewModel)
                             case .my:
                                 MyProfileView(path: $path)
                             case .personDetail(let friend):

--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -41,7 +41,7 @@ public struct ContentView: View {
     }
 
     public var body: some View {
-        VStack {
+        Group {
             switch userSession.appStep {
             case .login, .terms:
                 LoginView(loginViewModel: loginViewModel)

--- a/SwypApp2nd/Sources/CoreDataManager/PersonRepository.swift
+++ b/SwypApp2nd/Sources/CoreDataManager/PersonRepository.swift
@@ -1,24 +1,7 @@
 import CoreData
 
 class PersonRepository {
-//    private let context = CoreDataStack.shared.context
-//    
-//    func fetchPeople() -> [PersonEntity] {
-//        let request: NSFetchRequest<PersonEntity> = PersonEntity.fetchRequest()
-//        do {
-//            return try context.fetch(request)
-//        } catch {
-//            print("사람 목록 불러오기 실패: \(error.localizedDescription)")
-//            return []
-//        }
-//    }
-//    
-//        func deletePerson(_ person: PersonEntity) {
-//            context.delete(person)
-//            saveContext()
-//        }
-//
-//    private func saveContext() {
-//        CoreDataStack.shared.saveContext()
-//    }
+    
+  
+
 }

--- a/SwypApp2nd/Sources/CoreDataManager/PersonRepository.swift
+++ b/SwypApp2nd/Sources/CoreDataManager/PersonRepository.swift
@@ -1,34 +1,24 @@
 import CoreData
 
 class PersonRepository {
-    private let context = CoreDataStack.shared.context
-
-    func addPerson(name: String, reminderInterval: String) -> PersonEntity {
-        let newPerson = PersonEntity(context: context)
-        newPerson.id = UUID()
-        newPerson.name = name
-        newPerson.reminderInterval = reminderInterval
-
-        saveContext()
-        return newPerson
-    }
-
-    func fetchPeople() -> [PersonEntity] {
-        let request: NSFetchRequest<PersonEntity> = PersonEntity.fetchRequest()
-        do {
-            return try context.fetch(request)
-        } catch {
-            print("사람 목록 불러오기 실패: \(error.localizedDescription)")
-            return []
-        }
-    }
-    
-        func deletePerson(_ person: PersonEntity) {
-            context.delete(person)
-            saveContext()
-        }
-
-    private func saveContext() {
-        CoreDataStack.shared.saveContext()
-    }
+//    private let context = CoreDataStack.shared.context
+//    
+//    func fetchPeople() -> [PersonEntity] {
+//        let request: NSFetchRequest<PersonEntity> = PersonEntity.fetchRequest()
+//        do {
+//            return try context.fetch(request)
+//        } catch {
+//            print("사람 목록 불러오기 실패: \(error.localizedDescription)")
+//            return []
+//        }
+//    }
+//    
+//        func deletePerson(_ person: PersonEntity) {
+//            context.delete(person)
+//            saveContext()
+//        }
+//
+//    private func saveContext() {
+//        CoreDataStack.shared.saveContext()
+//    }
 }

--- a/SwypApp2nd/Sources/CoreDataManager/ReminderRepository.swift
+++ b/SwypApp2nd/Sources/CoreDataManager/ReminderRepository.swift
@@ -103,7 +103,11 @@ class ReminderRepository {
 
         do {
             if let entity = try context.fetch(fetchRequest).first {
-                return Friend(from: entity) 
+                var friend = UserSession.shared.user?.friends.filter({$0.id == entity.id}).first
+                
+                friend?.initEntity(from: entity)
+                print("[reminder repo] \(friend?.name ?? "nil" ) 로 설정됨)")
+                return friend
             } else {
                 print("[reminder repo] ❌ entity 연결 Friend 찾기 실패")
                 return nil

--- a/SwypApp2nd/Sources/CoreDataManager/ReminderRepository.swift
+++ b/SwypApp2nd/Sources/CoreDataManager/ReminderRepository.swift
@@ -8,7 +8,6 @@ class ReminderRepository {
         newReminder.id = person.id
         newReminder.date = scheduledDate
         newReminder.isRead = false
-        print(type.rawValue)
         newReminder.type = type.rawValue
         
         // MARK: - Person 연결
@@ -43,7 +42,6 @@ class ReminderRepository {
 
         newReminder.person = personEntity
 
-
         // 알림 브로드캐스트
         NotificationCenter.default.post(
             name: NSNotification.Name("NewReminderAdded"),
@@ -66,19 +64,19 @@ class ReminderRepository {
             }
         }
 
-    // 특정 `PersonEntity`에 대한 Reminder 가져오기
-    func fetchReminders(for person: PersonEntity) -> [ReminderEntity] {
-        let request: NSFetchRequest<ReminderEntity> = ReminderEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "person == %@", person)
-        request.sortDescriptors = [NSSortDescriptor(key: "Date", ascending: false)]
-
-        do {
-            return try context.fetch(request)
-        } catch {
-            print("❌ \(person.name)의 reminder 가져오기 실패: \(error.localizedDescription)")
-            return []
-        }
-    }
+//    // 특정 `PersonEntity`에 대한 Reminder 가져오기
+//    func fetchReminders(for person: PersonEntity) -> [ReminderEntity] {
+//        let request: NSFetchRequest<ReminderEntity> = ReminderEntity.fetchRequest()
+//        request.predicate = NSPredicate(format: "person == %@", person)
+//        request.sortDescriptors = [NSSortDescriptor(key: "Date", ascending: false)]
+//
+//        do {
+//            return try context.fetch(request)
+//        } catch {
+//            print("❌ \(person.name)의 reminder 가져오기 실패: \(error.localizedDescription)")
+//            return []
+//        }
+//    }
     
     // 모든 Reminder 가져오기
     func fetchAllReminders() -> [ReminderEntity] {

--- a/SwypApp2nd/Sources/GlobalState/NotificationManager.swift
+++ b/SwypApp2nd/Sources/GlobalState/NotificationManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UserNotifications
 import SwiftUI
 
 class NotificationManager: NSObject, ObservableObject, UNUserNotificationCenterDelegate {

--- a/SwypApp2nd/Sources/GlobalState/NotificationManager.swift
+++ b/SwypApp2nd/Sources/GlobalState/NotificationManager.swift
@@ -5,11 +5,11 @@ import SwiftUI
 class NotificationManager: NSObject, ObservableObject, UNUserNotificationCenterDelegate {
     
     static let shared = NotificationManager()
-    let notificationViewModel = NotificationViewModel()
-    let context = CoreDataStack.shared.context
     private let reminderRepo = ReminderRepository()
+    var notificationViewModel: NotificationViewModel
     
-    override private init() {
+    init(viewModel: NotificationViewModel = NotificationViewModel()) {
+        self.notificationViewModel = viewModel
         super.init()
         UNUserNotificationCenter.current().delegate = self
     }
@@ -64,11 +64,3 @@ class NotificationManager: NSObject, ObservableObject, UNUserNotificationCenterD
     }
 }
     
-extension NotificationManager {
-    
-//    // MARK: - 알림 등록
-//    func scheduleReminders(for person: Friend) {
-//        scheduleBirthdayAnniversaryReminder(for: person)
-//    }
- 
-}

--- a/SwypApp2nd/Sources/Models/Friend.swift
+++ b/SwypApp2nd/Sources/Models/Friend.swift
@@ -289,24 +289,7 @@ struct FriendInitResponseAnniversary: Codable {
 }
 
 extension Friend {
-    init(from entity: PersonEntity) {
-        self.id = entity.id
-        self.name = entity.name
-        self.image = nil
-        self.imageURL = nil
-        self.source = .phone
-        self.frequency = nil
-        self.remindCategory = nil
-        self.phoneNumber = nil
-        self.relationship = nil
-        self.birthDay = nil
-        self.anniversary = nil
-        self.memo = nil
-        self.nextContactAt = nil
-        self.lastContactAt = nil
-        self.checkRate = nil
-        self.position = nil
-        self.fileName = nil
+    mutating func initEntity(from entity: PersonEntity) {
         self.entity = entity
     }
 }

--- a/SwypApp2nd/Sources/Models/Friend.swift
+++ b/SwypApp2nd/Sources/Models/Friend.swift
@@ -289,21 +289,33 @@ struct FriendInitResponseAnniversary: Codable {
 }
 
 extension Friend {
+    init(from entity: PersonEntity) {
+        self.id = entity.id
+        self.name = entity.name
+        self.image = nil
+        self.imageURL = nil
+        self.source = .phone
+        self.frequency = nil
+        self.remindCategory = nil
+        self.phoneNumber = nil
+        self.relationship = nil
+        self.birthDay = nil
+        self.anniversary = nil
+        self.memo = nil
+        self.nextContactAt = nil
+        self.lastContactAt = nil
+        self.checkRate = nil
+        self.position = nil
+        self.fileName = nil
+        self.entity = entity
+    }
+}
+
+extension Friend {
     func toPersonEntity(context: NSManagedObjectContext) -> PersonEntity {
         let entity = PersonEntity(context: context)
         entity.id = self.id
         entity.name = self.name
-//        entity.imageURL = self.imageURL
-//        entity.phoneNumber = self.phoneNumber
-//        entity.relationship = self.relationship
-//        entity.birthDay = self.birthDay
-//        entity.anniversaryTitle = self.anniversary?.title
-//        entity.anniversaryDate = self.anniversary?.Date
-//        entity.memo = self.memo
-//        entity.nextContactAt = self.nextContactAt
-//        entity.lastContactAt = self.lastContactAt
-        entity.reminderInterval = self.frequency?.rawValue
-//        entity.position = Int64(self.position ?? 0)
         return entity
     }
 }

--- a/SwypApp2nd/Sources/Models/PersonEntity+CoreDataClass.swift
+++ b/SwypApp2nd/Sources/Models/PersonEntity+CoreDataClass.swift
@@ -6,15 +6,4 @@ public class PersonEntity: NSManagedObject {
     
     @NSManaged public var id: UUID
     @NSManaged public var name: String
-//    @NSManaged public var imageURL: String?
-//    @NSManaged public var phoneNumber: String?
-//    @NSManaged public var relationship: String?
-//    @NSManaged public var birthDay: Date?
-//    @NSManaged public var anniversaryTitle: String?
-//    @NSManaged public var anniversaryDate: Date?
-//    @NSManaged public var memo: String?
-//    @NSManaged public var nextContactAt: Date?
-//    @NSManaged public var lastContactAt: Date?
-    @NSManaged public var reminderInterval: String?
-//    @NSManaged public var position: Int
 }

--- a/SwypApp2nd/Sources/Models/PersonEntity+CoreDataProperties.swift
+++ b/SwypApp2nd/Sources/Models/PersonEntity+CoreDataProperties.swift
@@ -7,12 +7,14 @@ extension PersonEntity {
     @nonobjc public class func fetchRequest() -> NSFetchRequest<PersonEntity> {
         return NSFetchRequest<PersonEntity>(entityName: "PersonEntity")
     }
-    
-    static func mockPerson(context: NSManagedObjectContext) -> PersonEntity {
-        let person = PersonEntity(context: context)
-        person.name = "강다연"
-        return person
-        }
+}
+
+extension PersonEntity {
+    convenience init(context: NSManagedObjectContext, from friend: Friend) {
+        self.init(context: context)
+        self.id = friend.id
+        self.name = friend.name
+    }
 }
 
 // MARK: Generated accessors for reminders

--- a/SwypApp2nd/Sources/SwypApp2ndApp.swift
+++ b/SwypApp2nd/Sources/SwypApp2ndApp.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 @main
 struct SwypApp2ndApp: App {
+    
+    init() {
+            NotificationManager.shared.requestPermissionIfNeeded()
+        }
 
     var body: some Scene {
         WindowGroup {

--- a/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileEditViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileEditViewModel.swift
@@ -5,7 +5,7 @@ import CoreData
 class ProfileEditViewModel: ObservableObject {
     @Published var person: Friend
     
-    private let personRepo = PersonRepository()
+//    private let personRepo = PersonRepository()
     private let reminderRepo = ReminderRepository()
     
     @Published var people: [PersonEntity] = []
@@ -16,11 +16,11 @@ class ProfileEditViewModel: ObservableObject {
         self.people = people
     }
     
-    func addNewPerson(name: String,reminderInterval: String) {
-        let newPerson = personRepo.addPerson(name: name, reminderInterval: reminderInterval)
-        //entity id -> friend.id -> friend.type return
-//        reminderRepo.addReminder(person: newPerson, type: friend.type ., )
-    }
+//    func addNewPerson(name: String,reminderInterval: String) {
+//        let newPerson = personRepo.addPerson(name: name, reminderInterval: reminderInterval)
+//        //entity id -> friend.id -> friend.type return
+////        reminderRepo.addReminder(person: newPerson, type: friend.type ., )
+//    }
     
     // 친구 상세 정보 업데이트 메소드
     func updateFriendDetail(friendId: UUID, completion: @escaping () -> Void) {

--- a/SwypApp2nd/Sources/ViewModels/My/MyViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/My/MyViewModel.swift
@@ -2,9 +2,11 @@ import SwiftUI
 import Combine
 
 class MyViewModel: ObservableObject {
-    
-    @Published var isNotificationOn: Bool = UserDefaults.standard.bool(forKey: "isNotificationOn")
+//    
+    @Published var isNotificationOn: Bool = false
     @Published var showSettingsAlert: Bool = false
+    
+    
     @Published var selectedReason: String = ""
     @Published var customReason: String = ""
     @Published var showConfirmAlert: Bool = false
@@ -15,33 +17,58 @@ class MyViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     
     init() {
-        // 토글 감지
-        $isNotificationOn
-            .removeDuplicates()
-            .sink { [weak self] newValue in
-                guard let self = self else { return }
-                
-                if newValue {
-                    self.handleToggleOn()
-                }
-                UserDefaults.standard.set(newValue, forKey: "isNotificationOn")
+        observeAppForeground()
+     
+    }
+
+    // MARK: - 유저가 세팅 가서 알림 허용 했나 확인
+    func observeAppForeground() {
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .sink { [weak self] _ in
+                self?.checkNotificationStatusAfterSettings()
             }
             .store(in: &cancellables)
     }
-
     
+    func checkNotificationStatusAfterSettings() {
+            NotificationManager.shared.checkAuthorizationStatus { status in
+                DispatchQueue.main.async {
+                    switch status {
+                    
+                    case .authorized, .provisional:
+                        print("🟢 [MyViewModel] 알림 수동 켬 처리")
+                        UserDefaults.standard.set(false, forKey: "didManuallyDisableNotification")
+                        self.isNotificationOn = true
+                    
+                    case .denied, .notDetermined:
+                        self.isNotificationOn = false
+                    
+                    default:
+                        break
+                    }
+                }
+            }
+        }
+    
+    // MARK: - 첫 로딩 때 유저가 알림 허용 했는지 확인
     func loadInitialState() {
         NotificationManager.shared.checkAuthorizationStatus { status in
             switch status {
             case .authorized:
-                self.isNotificationOn = !UserDefaults.standard.bool(forKey: "didManuallyDisableNotification")
+                self.isNotificationOn = true
             default:
                 self.isNotificationOn = false
             }
         }
     }
     
-    private func handleToggleOn() {
+    func turnOffNotifications() {
+        isNotificationOn = false
+        NotificationManager.shared.disableNotifications()
+    }
+
+    
+    func handleToggleOn() {
         NotificationManager.shared.checkAuthorizationStatus { status in
             switch status {
                 case .denied, .notDetermined:
@@ -50,6 +77,7 @@ class MyViewModel: ObservableObject {
                     
                 case .authorized, .provisional:
                     if UserDefaults.standard.bool(forKey: "didManuallyDisableNotification") {
+                        print("🔴 [MyViewModel] 알림 수동 끔 처리")
                         self.showSettingsAlert = true
                         self.isNotificationOn = false
                     }

--- a/SwypApp2nd/Sources/ViewModels/My/ProfileEditViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/My/ProfileEditViewModel.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import CoreData
+
+class ProfileEditViewModel: ObservableObject {
+    @Published var person: Friend
+    @Published var people: [PersonEntity] = []
+    
+    init(person: Friend, people: [PersonEntity] = []) {
+        self.person = person
+        self.people = people
+    }
+}

--- a/SwypApp2nd/Sources/ViewModels/Notification/NotificationContainer.xcdatamodeld/NotificationContainer.xcdatamodel/contents
+++ b/SwypApp2nd/Sources/ViewModels/Notification/NotificationContainer.xcdatamodeld/NotificationContainer.xcdatamodel/contents
@@ -9,6 +9,7 @@
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isRead" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
         <relationship name="person" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PersonEntity" inverseName="reminders" inverseEntity="PersonEntity"/>
     </entity>
 </model>

--- a/SwypApp2nd/Sources/ViewModels/Notification/NotificationContainer.xcdatamodeld/NotificationContainer.xcdatamodel/contents
+++ b/SwypApp2nd/Sources/ViewModels/Notification/NotificationContainer.xcdatamodeld/NotificationContainer.xcdatamodel/contents
@@ -3,7 +3,6 @@
     <entity name="PersonEntity" representedClassName="PersonEntity" syncable="YES">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="reminderInterval" optional="YES" attributeType="String"/>
         <relationship name="reminders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ReminderEntity" inverseName="person" inverseEntity="ReminderEntity"/>
     </entity>
     <entity name="ReminderEntity" representedClassName="ReminderEntity" syncable="YES">

--- a/SwypApp2nd/Sources/ViewModels/Notification/NotificationViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Notification/NotificationViewModel.swift
@@ -35,8 +35,7 @@ class NotificationViewModel: ObservableObject {
     
     //MARK: - Inbox View에서 알림 스와이프해서 삭제 (알림 자체가 삭제되는 것 아님!)
     func deleteReminder(indexSet: IndexSet) {
-        let sorted = visibleReminders.sorted(by: { $0.date > $1.date })
-        let targets = indexSet.map { sorted[$0] }
+        let targets = indexSet.map { visibleReminders[$0] }
         targets.forEach { reminderRepo.deleteReminder($0) }
         loadAllReminders()
     }
@@ -149,22 +148,33 @@ class NotificationViewModel: ObservableObject {
             print("❌ 잘못된 리마인더 주기")
             return nil
         }
-        
-        var dateComponents = calendar.dateComponents([.year, .month, .day], from: nextDate)
-        dateComponents.hour = 23
-        dateComponents.minute = 16
+//
+//        var dateComponents = calendar.dateComponents([.year, .month, .day], from: nextDate)
+//        dateComponents.hour = 23
+//        dateComponents.minute = 32
+//        guard let scheduledDate = calendar.date(from: dateComponents) else { return nil }
+//
+        let future = Calendar.current.date(byAdding: .minute, value: 1, to: Date())!
+        let dateComponents = Calendar.current.dateComponents([.hour, .minute], from: future)
         guard let scheduledDate = calendar.date(from: dateComponents) else { return nil }
+
         
         let content = UNMutableNotificationContent()
         content.title = "📌 챙김 알림"
         content.body = "\(person.name)님에게 연락해보세요!"
         content.sound = .default
         content.badge = 1
-        content.userInfo = ["personID": person.id, "type": "regular"]
+        content.userInfo = ["personID": person.id.uuidString, "type": "regular"]
         
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
         
         print("🟢 [NotificationViewModel] \(person.name) 알림 등록 완료")
+        // ✅ 등록된 알림 확인 로그
+            UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
+                for req in requests {
+                    print("🧾 예약된 알림: \(req.identifier), trigger: \(req.trigger!)")
+                }
+            }
         return (content, trigger, scheduledDate, person.id)
     }
     

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -51,6 +51,13 @@ public struct HomeView: View {
         .onAppear {
             homeViewModel.loadFriendList()
         }
+        .onReceive(notificationViewModel.$navigateToPerson.compactMap { $0 }) { person in
+            DispatchQueue.main.async {
+                path = []
+                path.append(.personDetail(person))
+                notificationViewModel.navigateToPerson = nil
+            }
+        }
     }
 }
 

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -51,13 +51,10 @@ public struct HomeView: View {
         .onAppear {
             homeViewModel.loadFriendList()
         }
-        .onReceive(notificationViewModel.$navigateToPerson.compactMap { $0 }) { person in
-            DispatchQueue.main.async {
-                path = []
-                path.append(.personDetail(person))
-                notificationViewModel.navigateToPerson = nil
-            }
-        }
+        .onReceive(notificationViewModel.$navigateToPerson.compactMap { $0 }) { friend in
+            path.removeAll()
+            path.append(.personDetail(friend))
+        } 
     }
 }
 

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -121,14 +121,14 @@ struct ContactFrequencySettingsView: View {
                 }
 
                 Button{
-                    DispatchQueue.global().async {
-                    notificationViewModel.scheduleAnbu(people: UserSession.shared.user?.friends ?? [])
-                }
                     // 카카오는 이미지 저장 후 BackEnd 서버에 전송
                     viewModel.downloadKakaoImageData { friendsWithImages in
-                        viewModel.uploadAllFriendsToServer(viewModel.people) {
-                            UserSession.shared.user?.friends = viewModel.people
-                            complete(viewModel.people)
+                        DispatchQueue.main.async {
+                            viewModel.uploadAllFriendsToServer(viewModel.people) {
+                                UserSession.shared.user?.friends = viewModel.people
+                                notificationViewModel.scheduleAnbu(people: UserSession.shared.user?.friends ?? [])
+                                complete(viewModel.people)
+                            }
                         }
                         
                     }

--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -101,8 +101,6 @@ struct AccountSettingSectionView: View {
 
 struct NotificationSettingsView: View {
     @ObservedObject var viewModel: MyViewModel
-    @Environment(\.scenePhase) var scenePhase
-
     var body: some View {
         Toggle("알림설정", isOn: $viewModel.isNotificationOn)
             .padding(.horizontal)
@@ -111,9 +109,11 @@ struct NotificationSettingsView: View {
             .onAppear {
                 viewModel.loadInitialState()
             }
-            .onChange(of: scenePhase) { newPhase in
-                if newPhase == .active {
-                    viewModel.loadInitialState()
+            .onChange(of: viewModel.isNotificationOn) {newValue in
+                if newValue {
+                        viewModel.handleToggleOn()
+                } else {
+                    viewModel.turnOffNotifications()
                 }
             }
             .alert("휴대폰 알림이 꺼져 있어요.", isPresented: $viewModel.showSettingsAlert) {

--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -82,7 +82,7 @@ struct AccountSettingSectionView: View {
                     Spacer()
                     let (loginName, imageName): (String, String) = {
                         switch loginType {
-                        case .kakao: return ("카카오톡", "img_32_kakao")
+                        case .kakao: return ("카카오", "img_32_kakao")
                         case .apple: return ("애플", "img_32_apple")
                         }
                     }()

--- a/SwypApp2nd/Sources/Views/Notification/Notification.swift
+++ b/SwypApp2nd/Sources/Views/Notification/Notification.swift
@@ -1,1 +1,0 @@
-// Empty.swift

--- a/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
+++ b/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
@@ -41,10 +41,19 @@ struct ReminderListView: View {
     var body: some View {
         List {
             ForEach(notificationViewModel.reminders, id: \.self) { reminder in
-                ReminderRowView(notificationViewModel: notificationViewModel, reminder: reminder, person: reminder.person, onSelect: { person in
-                    let friend = Friend(from: person)
-                    path.append(.personDetail(friend))})
-                    .listRowBackground(reminder.isRead ? Color.bg02 : Color.white)
+                ReminderRowView(notificationViewModel: notificationViewModel,
+                                reminder: reminder,
+                                person: reminder.person,
+                                onSelect: { person in
+                    
+                    var friend = UserSession.shared.user?.friends.filter({$0.id == person.id}).first
+                    
+                    friend?.initEntity(from: person)
+                    if let friend = friend {
+                        path.append(.personDetail(friend))
+                    }
+                })
+                .listRowBackground(reminder.isRead ? Color.bg02 : Color.white)
             }
             .onDelete(perform: notificationViewModel.deleteReminder)
         }

--- a/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
+++ b/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
@@ -42,7 +42,8 @@ struct ReminderListView: View {
         List {
             ForEach(notificationViewModel.reminders, id: \.self) { reminder in
                 ReminderRowView(notificationViewModel: notificationViewModel, reminder: reminder, person: reminder.person, onSelect: { person in
-                    path.append(.person(person))})
+                    let friend = Friend(from: person)
+                    path.append(.personDetail(friend))})
                     .listRowBackground(reminder.isRead ? Color.bg02 : Color.white)
             }
             .onDelete(perform: notificationViewModel.deleteReminder)

--- a/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
+++ b/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
@@ -2,11 +2,10 @@ import SwiftUI
 
 struct NotificationInboxView: View {
     @Binding var path: [AppRoute]
-    @EnvironmentObject var notificationViewModel: NotificationViewModel
+    @ObservedObject var notificationViewModel: NotificationViewModel
 
     var body: some View {
         VStack {
-//            headerView
             bodyView
         }
         .navigationTitle("알림")
@@ -15,21 +14,9 @@ struct NotificationInboxView: View {
         }
     }
 
-//    private var headerView: some View {
-//        HStack {
-//            Spacer()
-//            NavigationLink(destination: ProfileEditView(profileEditViewModel: <#ProfileEditViewModel#>)) {
-//                Image(systemName: "gear")
-//                    .resizable()
-//                    .frame(width: 20, height: 20)
-//                    .padding()
-//            }
-//        }
-//    }
-
     private var bodyView: some View {
         VStack {
-            if notificationViewModel.visibleReminders.isEmpty {
+            if notificationViewModel.reminders.isEmpty {
                 Text("오늘 예정된 알림이 없어요!")
                     .foregroundColor(.gray)
                     .padding()
@@ -40,7 +27,7 @@ struct NotificationInboxView: View {
                     }) {
                         Label("전체 삭제하기", systemImage: "trash")
                     }
-                    ReminderListView(path: $path, reminders: notificationViewModel.visibleReminders)
+                    ReminderListView(path: $path, notificationViewModel: notificationViewModel)
                 }
             }
         }
@@ -48,14 +35,13 @@ struct NotificationInboxView: View {
 }
 
 struct ReminderListView: View {
-    @EnvironmentObject var notificationViewModel: NotificationViewModel
     @Binding var path: [AppRoute]
-    var reminders: [ReminderEntity]
-
+    @ObservedObject var notificationViewModel: NotificationViewModel
+    
     var body: some View {
         List {
-            ForEach(notificationViewModel.visibleReminders, id: \.self) { reminder in
-                ReminderRowView(reminder: reminder, person: reminder.person, onSelect: { person in
+            ForEach(notificationViewModel.reminders, id: \.self) { reminder in
+                ReminderRowView(notificationViewModel: notificationViewModel, reminder: reminder, person: reminder.person, onSelect: { person in
                     path.append(.person(person))})
                     .listRowBackground(reminder.isRead ? Color.bg02 : Color.white)
             }
@@ -66,7 +52,7 @@ struct ReminderListView: View {
 }
 
 struct ReminderRowView: View {
-    @EnvironmentObject var notificationViewModel: NotificationViewModel
+    @ObservedObject var notificationViewModel: NotificationViewModel
     var reminder: ReminderEntity
     var person: PersonEntity
     var onSelect: (PersonEntity) -> Void
@@ -128,18 +114,18 @@ private struct ReminderContent: View {
     }
 }
 
-struct NotificationInboxView_Previews: PreviewProvider {
-    struct PreviewWrapper: View {
-        @State var dummyPath: [AppRoute] = []
-
-        var body: some View {
-            NotificationInboxView(path: $dummyPath)
-                .environmentObject(UserSession.shared)
-                .environmentObject(NotificationManager.shared.notificationViewModel)
-        }
-    }
-
-    static var previews: some View {
-        PreviewWrapper()
-    }
-}
+//struct NotificationInboxView_Previews: PreviewProvider {
+//    struct PreviewWrapper: View {
+//        @State var dummyPath: [AppRoute] = []
+//
+//        var body: some View {
+//            NotificationInboxView(path: $dummyPath)
+//                .environmentObject(UserSession.shared)
+//                .environmentObject(NotificationManager.shared.notificationViewModel)
+//        }
+//    }
+//
+//    static var previews: some View {
+//        PreviewWrapper()
+//    }
+//}


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 로컬 알림을 고쳐서 1분 뒤에 오게 만들었습니다

## 📄 작업 내용 상세 설명
- 리마인드의 id, "personID": personEntity.id.uuidString도 friend id와 동일하게 설정했습니다.

### 🎯 작업 목적
- 친구 import 시 주기 설정뷰에서 완료를 누르면 자동으로 안부 알림이 설정 됩니다.

### 🛠️ 주요 변경 사항
- inbox view에서 알림 클릭시 상세 프로필로 이동
- 안부 알림 설정

### 📸 스크린샷 (필요시 추가)
![ScreenRecording2025-04-25at1 08 56AM-ezgif com-resize](https://github.com/user-attachments/assets/0460c2e7-8ab7-4e94-9b80-3d0634c30d47)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
-  안부 설정 시 설정 되었다는 토스트가 필요할까요?
- personEntity id랑 friend id 랑 연결 되게 설정한 줄 알았는데 안되는 모양입니다... 알림을 클릭하면 아직 프로필 상세로 이동하지 않아요. -- fetchPerson에 문제가 있는 것 같습니다. "personID": personEntity.id.uuidString로 설정했는데 왜 fetchPerson에서 friend.entity.id를 print 하면 nil이 뜨는지 잘 모르겠어요.. (그래서 인박스 뷰에서는 사실 유저 데이터를 어떻게 들고 올 수 있는지.. 잘 모르겠습니다 더 봐야할 것 같아요)
- 유저가 매일로 주기를 설정했을 때만 1분 뒤로 오게끔 코드 업데이트가 필요합니다
- 인박스 뷰에서 알림 날짜가 이상하게 뜹니다.
- 토글 껐다 켰다 하는 코드를 다듬었는데 아직 테스트를 못해봤습니다.
- 아직 친구 연락처에 있는 생일을 가져와서 생일, 기념일을 자동으로 설정하는 기능은 미구현 상태입니다

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #이슈번호
- 관련 PR: #PR번호