### PR TITLE
[Feature] 친구 챙김 기록 기능 추가

### DIFF
--- a/SwypApp2nd/Sources/Common/Date+Extension.swift
+++ b/SwypApp2nd/Sources/Common/Date+Extension.swift
@@ -113,6 +113,12 @@ extension Date {
         return formatter.string(from: self)
     }
     
+    func formattedYYMMDDWithDot() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yy.MM.dd"
+        return formatter.string(from: self)
+    }
+    
     func formattedYYYYMMDDMoreCloser() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "M월 dd일 더 가까워졌어요"

--- a/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
@@ -71,7 +71,7 @@ class ProfileDetailViewModel: ObservableObject {
         }
     }
     
-    // 친구 상세 API 사용 메소드
+    // 친구 챙김 기록 API
     func fetchFriendRecords(friendId: UUID) {
         guard let token = UserSession.shared.user?.serverAccessToken else { return }
         
@@ -79,7 +79,7 @@ class ProfileDetailViewModel: ObservableObject {
             switch result {
             case .success(let checkInRecords):
                 DispatchQueue.main.async {
-                    self.checkInRecords = checkInRecords
+                    self.checkInRecords = checkInRecords.sorted { $0.createdAt > $1.createdAt }
                 }
                     
             case .failure(let error):

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
@@ -33,14 +33,18 @@ struct ProfileDetailView: View {
             
             ZStack {
                 ProfileInfoSection(people: viewModel.people)
-                    .padding(.top, -82)
+                    .padding(.top, -16)
                     .opacity(selectedTab == .profile ? 1 : 0)
-                HistorySection(people: viewModel.people)
+                HistorySection(records: viewModel.checkInRecords)
                     .opacity(selectedTab == .records ? 1 : 0)
             }
+            .padding(.bottom, 8)
             
-            ConfirmButton(title: "챙김 기록하기") {
-                // TODO: - 챙김 기록 API 필요
+            ConfirmButton(
+                title: viewModel.canCheckInToday ? "챙김 기록하기" : "챙김 기록 완료",
+                isEnabled: viewModel.canCheckInToday
+            ) {
+                viewModel.checkFriend()
             }
         }
         .padding(.horizontal, 24)
@@ -96,22 +100,18 @@ struct ProfileDetailView: View {
     }
 }
 
-struct CheckInRecord: Identifiable {
-    let id = UUID()
-    let index: Int
-    let date: Date
-}
-
 struct HistorySection: View {
-    let people: Friend
+    let records: [CheckInRecord]
     
-    let records: [CheckInRecord] = (1...14).map {
-        CheckInRecord(
-            index: $0,
-            date: Date().addingTimeInterval(TimeInterval(-$0 * 86400))
+    var filteredRecords: [(offset: Int, element: CheckInRecord)] {
+        Array(
+            records
+                .filter { $0.isChecked }
+                .sorted(by: { $0.createdAt > $1.createdAt })
+                .enumerated()
         )
     }
-
+    
     let columns = [
         GridItem(.flexible(), spacing: 12),
         GridItem(.flexible(), spacing: 12),
@@ -119,30 +119,54 @@ struct HistorySection: View {
     ]
     
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                Text("챙김 기록")
-                    .font(Font.Pretendard.h2Bold())
-                    .foregroundColor(.black)
-
-                LazyVGrid(columns: columns, spacing: 24) {
-                    ForEach(records.sorted(by: { $0.index > $1.index })) { record in
-                        VStack(spacing: 8) {
-                            Image("img_100_character_success")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 64, height: 64)
-
-                            Text("\(record.index)번째 챙김")
-                                .font(Font.Pretendard.captionBold())
-                                .foregroundColor(.blue01)
-
-                            Text(record.date.formattedYYYYMMDD())
-                                .font(Font.Pretendard.captionMedium())
-                                .foregroundColor(.gray02)
-                        }
-                        .frame(maxWidth: .infinity)
+      
+        VStack(alignment: .leading, spacing: 16) {
+            Text("챙김 기록")
+                .font(Font.Pretendard.h2Bold())
+                .foregroundColor(.black)
+            ScrollView {
+                if records.isEmpty {
+                    VStack {
+                        Spacer()
+                        Text("챙긴 기록이 없어요.\n오늘 챙겨볼까요?")
+                            .font(Font.Pretendard.b1Bold())
+                            .foregroundColor(.blue02)
+                            .multilineTextAlignment(.center)
+                        Spacer()
                     }
+                    .frame(maxWidth: .infinity)
+                } else {
+                    LazyVGrid(columns: columns, spacing: 24) {
+                        ForEach(filteredRecords, id: \.element.id) { index, record in
+                            VStack(spacing: 8) {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 44, style: .continuous)
+                                        .fill(Color.white)
+                                        .frame(width: 98, height: 98)
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 44, style: .continuous)
+                                                .stroke(Color.gray03, lineWidth: 1)
+                                        )
+                                    
+                                    VStack(spacing: 4) {
+                                        Image("img_100_character_success")
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 40, height: 40)
+                                                                           
+                                        Text("\(index + 1)번째 챙김")
+                                            .font(Font.Pretendard.b2Medium())
+                                            .foregroundColor(.blue01)
+                                    }
+                                }
+                                Text(record.createdAt.formattedYYMMDDWithDot())
+                                    .font(Font.Pretendard.b2Medium())
+                                    .foregroundColor(.gray01)
+                            }
+                            
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
                 }
             }
         }
@@ -419,7 +443,7 @@ private struct MemoRow: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: 100, alignment: .topLeading)
         .background(Color.white)
         .cornerRadius(10)
         .overlay(
@@ -431,17 +455,20 @@ private struct MemoRow: View {
 
 private struct ConfirmButton: View {
     var title: String
+    var isEnabled: Bool = true
     var action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Text(title)
+                .font(Font.Pretendard.b1Medium())
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color.blue01)
+                .background(isEnabled ? Color.blue01 : Color.gray02)
                 .cornerRadius(12)
         }
+        .disabled(!isEnabled)
     }
 }
 
@@ -470,7 +497,8 @@ struct ProfileDetailView_Previews: PreviewProvider {
                     relationship: "동료",
                     birthDay: Date(),
                     anniversary: AnniversaryModel(title: "결혼기념일", Date: Date()),
-                    memo: "테스트 메모",
+//                    memo: "Lorem ipsum dolor sit amet consectetur adipiscing elit quisque faucibus ex sapien vitae pellentesque",
+                    memo: "",
                     nextContactAt: Date().addingTimeInterval(86400 * 30),
                     lastContactAt: Date().addingTimeInterval(-86400 * 10),
                     checkRate: 75,

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
@@ -15,7 +15,7 @@ struct ProfileDetailView: View {
         
         VStack(alignment: .leading, spacing: 32) {
             
-            ProfileHeader(people: viewModel.people, onDelete: {
+            ProfileHeader(people: viewModel.people, checkInRecords: viewModel.checkInRecords, onDelete: {
                 viewModel.deleteFriend(friendId: viewModel.people.id) {
                     DispatchQueue.main.async {
                         path.removeAll()
@@ -175,6 +175,7 @@ struct HistorySection: View {
 
 private struct ProfileHeader: View {
     let people: Friend
+    let checkInRecords: [CheckInRecord]
     let onDelete: () -> Void
     
     var emojiImageName: String {
@@ -215,9 +216,16 @@ private struct ProfileHeader: View {
                     .font(Font.Pretendard.h2Bold())
                     .multilineTextAlignment(.center)
                 
-                Text("\(people.lastContactAt?.formattedYYYYMMDDMoreCloser() ?? "-")") //MM월dd일 더 가까워졌어요
-                    .font(Font.Pretendard.b1Medium())
-                    .foregroundColor(Color.blue01)
+                //MM월dd일 더 가까워졌어요
+                if let latestRecordDate = checkInRecords.sorted(by: { $0.createdAt > $1.createdAt }).first?.createdAt {
+                    Text("\(latestRecordDate.formattedYYYYMMDDMoreCloser())")
+                        .font(Font.Pretendard.b2Medium())
+                        .foregroundColor(Color.blue01)
+                } else {
+                    Text("-")
+                        .font(Font.Pretendard.b2Medium())
+                        .foregroundColor(Color.blue01)
+                }
             }
         }
         


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 챙김 기록 기능 구현 및 API 연동
- ‘챙김 기록하기’ 버튼 활성화 / 비활성화 조건 적용
- 챙김 기록 레이아웃 개선
- 마지막 챙김 날자 적용

## 📄 작업 내용 상세 설명
- POST /friend/record/{friendId} API를 연동하여 챙김 기록 저장
- GET /friend/record/{friendId} API를 통해 친구별 챙김 기록 목록 조회
- 당일에 이미 챙긴 기록(isChecked == true)이 있으면 ‘챙김 기록하기’ 버튼 비활성화 및 색상 회색 처리
- ProfileDetailView 하단에 ‘챙김 기록하기’ 버튼 추가
- HistorySection에 챙긴 기록(isChecked == true)만 날짜순 정렬하여 표시
- 챙긴 기록 카드에 n번째 챙김 번호와 날짜를 함께 표시
- 메모 유무에 따라 레이아웃이 흔들리지 않도록 MemoRow에 최소 높이(minHeight) 설정
- ConfirmButton 색상 및 활성화 상태에 따른 스타일 분기 적용

### 🎯 작업 목적
- 사용자가 친구를 챙긴 기록을 서버에 반영하고, 기록이 UI에 반영
- 당일 중복 챙김을 방지

### 🛠️ 주요 변경 사항
- ProfileDetailViewModel: 챙김 기록 관련 API (fetchFriendRecords, checkFriend) 추가
- ProfileDetailView: 챙김 기록 버튼 기능 구현, 챙김 기록 구현
- ConfirmButton: 활성/비활성 상태 지원

### 📸 스크린샷 (필요시 추가)

https://github.com/user-attachments/assets/17e40893-3157-40de-899f-5f1695b8667e

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 아이폰 기기별 UI 대응이 필요할것같습니다

### ✅ 참고 이슈 및 관련 작업
- https://github.com/SWYP-App-2nd/iOS/issues/57
- https://github.com/SWYP-App-2nd/iOS/issues/55