### PR TITLE
[FIX] 약관 동의 dim 터치 이슈 해결 - #61

### DIFF
--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -18,10 +18,6 @@ enum AppRoute: Hashable {
     case personDetail(Friend)
 }
 
-enum ProfileDetailRoute {
-    case edit
-}
-
 public struct ContentView: View {
     @StateObject private var userSession = UserSession.shared
     @StateObject private var loginViewModel = LoginViewModel()
@@ -32,7 +28,6 @@ public struct ContentView: View {
     @StateObject private var contactFrequencyViewModel = ContactFrequencySettingsViewModel()
     @StateObject private var myViewModel = MyViewModel()
     
-    private let skipLoginForTesting: Bool = true
     @State private var path: [AppRoute] = []
     
     public init() {
@@ -88,7 +83,13 @@ public struct ContentView: View {
         }
         .sheet(isPresented: Binding<Bool>(
             get: { userSession.appStep == .terms },
-            set: { if !$0 { userSession.appStep = .registerFriends } }
+            set: { isPresented in
+                if !isPresented {
+                    if userSession.appStep == .terms {
+                        userSession.appStep = .login
+                    }
+                }
+            }
         )) {
             TermsView(viewModel: termsViewModel) {
                 DispatchQueue.main.async {


### PR DESCRIPTION
## ✨ 변경 사항 요약
- TermsView가 모달로 올라왔을 때, Dim(배경) 영역을 터치하여 dismiss 하면 다음 화면으로 넘어가는 문제 해결

## 📄 작업 내용 상세 설명
- .sheet의 set 블록에서, isPresented == false가 되었을 때 userSession.appStep을 .login으로 명시적으로 설정하도록 수정. 이를 통해 TermsView가 강제로 내려간 경우에도
RegisterFriends 화면으로 넘어가지 않고, 다시 LoginView로 복귀.

### 🎯 작업 목적
- 약관에 동의하지 않은 사용자가 Dim 터치로 모달을 닫았을 때 다음 단계로 넘어가는 잘못된 흐름을 방지

### 🛠️ 주요 변경 사항
- ContentView.swift .sheet() 수정

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #61 