### PR TITLE
[Feature] 이번달 챙김 목록 API 연동

### DIFF
--- a/SwypApp2nd/Sources/Common/Date+Extension.swift
+++ b/SwypApp2nd/Sources/Common/Date+Extension.swift
@@ -110,18 +110,24 @@ extension Date {
     func formattedYYYYMMDDWithDot() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy.MM.dd"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter.string(from: self)
     }
     
     func formattedYYMMDDWithDot() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yy.MM.dd"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter.string(from: self)
     }
     
     func formattedYYYYMMDDMoreCloser() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "M월 dd일 더 가까워졌어요"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter.string(from: self)
     }
 

--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -59,6 +59,7 @@ public struct ContentView: View {
                         registerFriendsViewModel.selectedContacts.removeAll()
                         contactFrequencyViewModel.people.removeAll()
                         homeViewModel.loadFriendList()
+                        homeViewModel.loadMonthlyFriends()
                         userSession.appStep = .home
                     }
                 })

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -156,6 +156,14 @@ struct FriendUpdateRequestAnniversaryDTO: Codable {
     var date: String?
 }
 
+// MARK: - 이번달 챙길 친구
+struct FriendMonthlyResponse: Codable {
+    var friendId: String
+    var name: String
+    var type: String
+    var nextContactAt: String
+}
+
 // MARK: - 서버 통신 로직
 final class BackEndAuthService {
     static let shared = BackEndAuthService()
@@ -649,24 +657,68 @@ final class BackEndAuthService {
             }
     }
     
+    /// 백엔드: 챙기기 버튼 클릭
     func postFriendCheck(friendId: UUID, accessToken: String, completion: @escaping (Result<String, Error>) -> Void) {
-            let url = "\(baseURL)/friend/record/\(friendId.uuidString)"
+        let url = "\(baseURL)/friend/record/\(friendId.uuidString)"
             
-            let headers: HTTPHeaders = [
-                "Authorization": "Bearer \(accessToken)"
-            ]
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
             
-            AF.request(url, method: .post, headers: headers)
-                .validate()
-                .responseDecodable(of: RecordButtonResponse.self) { response in
-                    switch response.result {
-                    case .success(let result):
-                        completion(.success(result.message))
-                    case .failure(let error):
-                        completion(.failure(error))
-                    }
+        AF.request(url, method: .post, headers: headers)
+            .validate()
+            .responseDecodable(of: RecordButtonResponse.self) { response in
+                switch response.result {
+                case .success(let result):
+                    completion(.success(result.message))
+                case .failure(let error):
+                    completion(.failure(error))
                 }
-        }
+            }
+    }
+    
+    /// 백엔드: 이번달 챙길 친구 조회
+    func getMonthlyFriends(accessToken: String, completion: @escaping (Result<[FriendMonthlyResponse], Error>) -> Void) {
+        let url = "\(baseURL)/friend/monthly"
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
+        
+        print("🟡 [BackEndAuthService] 이번달 친구 조회 요청 URL: \(url)")
+        
+        AF.request(url, method: .get, headers: headers)
+            .validate()
+            .responseDecodable(
+                of: [FriendMonthlyResponse].self
+            ) { response in
+                switch response.result {
+                case .success(let monthlyFriends):
+                    print(
+                        "🟢 [BackEndAuthService] 이번달 친구 조회 성공 - \(monthlyFriends.map { $0.name })"
+                    )
+                    do {
+                        let encoder = JSONEncoder()
+                        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                        let jsonData = try encoder.encode(monthlyFriends)
+                        if let jsonString = String(
+                            data: jsonData,
+                            encoding: .utf8
+                        ) {
+                            print(
+                                "🟡 [getMonthlyFriends] 서버 응답 JSON:\n\(jsonString)"
+                            )
+                        }
+                    } catch {
+                        print(
+                            "🔴 [getMonthlyFriends] 서버 응답 JSON 인코딩 실패: \(error)"
+                        )
+                    }
+                    completion(.success(monthlyFriends))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+    }
 }
 
 

--- a/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
@@ -6,7 +6,7 @@ class HomeViewModel: ObservableObject {
     /// 내 사람들
     @Published var allFriends: [Friend] = []
     /// 이번달 챙길 사람
-    @Published var thisMonthFriends: [Friend] = []
+    @Published var thisMonthFriends: [FriendMonthlyResponse] = []
     private var cancellables = Set<AnyCancellable>()
 
     
@@ -61,6 +61,30 @@ class HomeViewModel: ObservableObject {
                 }
             }
         }.resume()
+    }
+    
+    // 이번달 챙길 사람 목록 가져오기
+    func loadMonthlyFriends() {
+        guard let token = UserSession.shared.user?.serverAccessToken else { return }
+        
+        BackEndAuthService.shared.getMonthlyFriends(accessToken: token) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let monthlyFriendDTOs):
+                    self.thisMonthFriends = monthlyFriendDTOs.map { dto in
+                        FriendMonthlyResponse(
+                            friendId: dto.friendId,
+                                name: dto.name,
+                                type: dto.type.uppercased(),
+                                nextContactAt: dto.nextContactAt
+                            )
+                        
+                    }
+                case .failure(let error):
+                    print("🔴 [HomeViewModel] 이번달 친구 목록 로드 실패: \(error)")
+                }
+            }
+        }
     }
     
     func loadFriendList() {

--- a/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
@@ -5,11 +5,13 @@ class ProfileDetailViewModel: ObservableObject {
     @Published var checkInRecords: [CheckInRecord] = []
     
     var canCheckInToday: Bool {
-        let today = Calendar.current.startOfDay(for: Date())
+        var calendar = Calendar.current
+        calendar.timeZone = TimeZone(abbreviation: "UTC")!
 
-        // createdAt이 오늘 && isChecked true
+        let today = calendar.startOfDay(for: Date())
+
         return !checkInRecords.contains { record in
-            let recordDate = Calendar.current.startOfDay(for: record.createdAt)
+            let recordDate = calendar.startOfDay(for: record.createdAt)
             return recordDate == today && record.isChecked
         }
     }

--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -64,7 +64,14 @@ class RegisterFriendsViewModel: ObservableObject {
             let anniversaryDayTitle = $0.dates.first?.label
             let anniversary: AnniversaryModel? = {
                 guard let date = anniversaryDay else { return nil }
-                return AnniversaryModel(title: anniversaryDayTitle, Date: date)
+                guard var title = anniversaryDayTitle else { return nil }
+                if title == "_$!<Anniversary>!$_" || title.isEmpty {
+                    title =  "기념일"
+                } else {
+                    title = title
+                }
+                
+                return AnniversaryModel(title: title, Date: date)
             }()
             let relationship = $0.contactRelations.first?.label
             


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 이번달 챙길 사람 조회 API(/friend/monthly) 연동
- 연락처 추가 시 기념일 제목이 없는 경우에 대한 예외 처리
- 챙김 기록 날짜 비교 시 UTC 시간 기준으로 비교하도록 수정

## 📄 작업 내용 상세 설명
- GET /friend/monthly API를 호출해 이번 달에 생일, 기념일, 챙김이 예정된 친구 목록을 받아옴
- 연락처에서 가져온 기념일 중 제목이 비어있는 경우 _!<Anniversary>!_ 등의 이상 문자열이 표시되는 이슈 수정
- reatedAt 날짜 비교 시 Calendar.current.startOfDay(for:) 대신 UTC 기준으로 startOfDay를 구하는 방식 적용

### 🎯 작업 목적
- 이번달에 챙겨야 할 친구 정보를 서버 API 연동으로 받아옴

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 이번달 챙길 사람 API 수정중임으로 작동 이슈

### ✅ 참고 이슈 및 관련 작업
- 관련 PR: #58 