### PR TITLE
[Feature] contact Frequency setting 할 때 안부와 기념일, 생일 알림 저장될 수 있도록 알림 기능 구현

### DIFF
--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -57,6 +57,7 @@ public struct ContentView: View {
                     DispatchQueue.main.async {
                         print("🟢 [ContactFrequencySettingsView] 전달받은 people: \(updatedPeoples.map { $0.name })")
                         registerFriendsViewModel.selectedContacts.removeAll()
+                        notificationViewModel.scheduleNotifications(people: contactFrequencyViewModel.people)
                         contactFrequencyViewModel.people.removeAll()
                         homeViewModel.loadFriendList()
                         userSession.appStep = .home
@@ -75,7 +76,7 @@ public struct ContentView: View {
                                 MyProfileView(path: $path)
                             case .personDetail(let friend):
                                 let profileDetailViewModel = ProfileDetailViewModel(people: friend)
-                                ProfileDetailView(viewModel: profileDetailViewModel, path: $path)
+                                ProfileDetailView(viewModel: profileDetailViewModel, notificationViewModel: notificationViewModel, path: $path)
                             }
                         }
                 }

--- a/SwypApp2nd/Sources/Models/Friend.swift
+++ b/SwypApp2nd/Sources/Models/Friend.swift
@@ -21,7 +21,6 @@ struct Friend: Identifiable, Equatable, Hashable, Codable {
     var checkRate: Int? // 챙김률
     var position: Int? // 내사람들 리스트 순서
     var fileName: String? // 서버에서 받은 (friend.id).jpg
-    var entity: PersonEntity?
     
     enum CodingKeys: String, CodingKey {
         case id, name, imageURL, source, frequency, remindCategory,
@@ -286,19 +285,4 @@ struct FriendInitResponseAnniversary: Codable {
     let id: Int
     let title: String
     let date: String
-}
-
-extension Friend {
-    mutating func initEntity(from entity: PersonEntity) {
-        self.entity = entity
-    }
-}
-
-extension Friend {
-    func toPersonEntity(context: NSManagedObjectContext) -> PersonEntity {
-        let entity = PersonEntity(context: context)
-        entity.id = self.id
-        entity.name = self.name
-        return entity
-    }
 }

--- a/SwypApp2nd/Sources/Models/PersonEntity+CoreDataClass.swift
+++ b/SwypApp2nd/Sources/Models/PersonEntity+CoreDataClass.swift
@@ -6,4 +6,5 @@ public class PersonEntity: NSManagedObject {
     
     @NSManaged public var id: UUID
     @NSManaged public var name: String
+    @NSManaged public var reminders: NSSet?
 }

--- a/SwypApp2nd/Sources/Models/PersonEntity+CoreDataProperties.swift
+++ b/SwypApp2nd/Sources/Models/PersonEntity+CoreDataProperties.swift
@@ -31,7 +31,6 @@ extension PersonEntity {
 
     @objc(removeReminders:)
     @NSManaged public func removeFromReminders(_ values: NSSet)
-
 }
 
 extension PersonEntity : Identifiable {

--- a/SwypApp2nd/Sources/Models/ReminderEntity+CoreDataClass.swift
+++ b/SwypApp2nd/Sources/Models/ReminderEntity+CoreDataClass.swift
@@ -8,4 +8,5 @@ public class ReminderEntity: NSManagedObject {
     @NSManaged var isRead: Bool
     @NSManaged var person: PersonEntity
     @NSManaged var type: String
+    @NSManaged var isTriggered: Bool
 }

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -421,11 +421,11 @@ final class BackEndAuthService {
 
     // 백엔드: 리마인더 전송
     func sendReminder(friendId: UUID, accessToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        let url = "\(baseURL)/friend/reminder"
+        let url = "\(baseURL)/friend/reminder/\(friendId.uuidString)"
         let headers : HTTPHeaders = ["Authorization":  "Bearer \(accessToken)"]
-        let params: Parameters = [ "friend-id": friendId.uuidString]
+//        let params: Parameters = [ "friend-id": friendId.uuidString]
 
-        AF.request(url, method: .post, parameters: params, encoding: URLEncoding(destination: .queryString), headers: headers)
+        AF.request(url, method: .post, headers: headers)
             .validate(statusCode: 200..<300)
             .response { response in
                 switch response.result {

--- a/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileEditViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileEditViewModel.swift
@@ -16,12 +16,6 @@ class ProfileEditViewModel: ObservableObject {
         self.people = people
     }
     
-//    func addNewPerson(name: String,reminderInterval: String) {
-//        let newPerson = personRepo.addPerson(name: name, reminderInterval: reminderInterval)
-//        //entity id -> friend.id -> friend.type return
-////        reminderRepo.addReminder(person: newPerson, type: friend.type ., )
-//    }
-    
     // 친구 상세 정보 업데이트 메소드
     func updateFriendDetail(friendId: UUID, completion: @escaping () -> Void) {
         

--- a/SwypApp2nd/Sources/ViewModels/Notification/NotificationContainer.xcdatamodeld/NotificationContainer.xcdatamodel/contents
+++ b/SwypApp2nd/Sources/ViewModels/Notification/NotificationContainer.xcdatamodeld/NotificationContainer.xcdatamodel/contents
@@ -9,6 +9,7 @@
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isRead" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isTriggered" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="type" optional="YES" attributeType="String"/>
         <relationship name="person" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PersonEntity" inverseName="reminders" inverseEntity="PersonEntity"/>
     </entity>

--- a/SwypApp2nd/Sources/ViewModels/Notification/NotificationViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Notification/NotificationViewModel.swift
@@ -10,49 +10,108 @@ class NotificationViewModel: ObservableObject {
     
     @Published var navigateToPerson: Friend?
     @Published var reminders: [ReminderEntity] = []
-    @Published var badgeCount: Int = 0
+    @Published var showBadge: Bool = false
     @Published var showToast: Bool = false
     
     init() {
         loadAllReminders() // CoreData에서 기존 리마인더 불러오기
-        setBadgeCount() // 뱃지 숫자 세팅
+        setShowBadge() // 뱃지 숫자 세팅
         observeReminderAdded() // 알림 구독해서 새로 생긴 리마인더 감지 -> 추후 코멘트 아웃
     }
     
     func loadAllReminders() {
-        setBadgeCount()
+        setShowBadge()
         reminders = reminderRepo.fetchAllReminders()
     }
     
-    // MARK: - 비동기로 안 읽은 알림 수 계산해서 뱃지 업데이트 (홈에서 종버튼에 사용)
-    func setBadgeCount() {
+    /// 비동기로 안 읽은 알림 수 계산해서 뱃지 업데이트 (홈에서 종버튼에 사용)
+    func setShowBadge() {
         $reminders
-            .map { $0.filter { !$0.isRead }.count } // 안 읽은 알림 개수 계산
-            .assign(to: \.badgeCount, on: self)
+            .receive(on: DispatchQueue.main)
+            .map { reminders in
+                        reminders.contains(where: { $0.isTriggered && !$0.isRead }
+                )
+            }
+            .assign(to: \.showBadge, on: self)
             .store(in: &cancellables)
     }
     
     
-    //MARK: - Inbox View에서 알림 스와이프해서 삭제 (알림 자체가 삭제되는 것 아님!)
+    /// Inbox View에서 알림 스와이프해서 삭제 (알림 자체가 삭제되는 것 아님!)
     func deleteReminder(indexSet: IndexSet) {
-        let targets = indexSet.map { visibleReminders[$0] }
-        targets.forEach { reminderRepo.deleteReminder($0) }
-        loadAllReminders()
+        guard let index = indexSet.first else { return }
+        let reminderToDelete = visibleReminders[index]
+        
+        context.delete(reminderToDelete) // CoreData에서도 삭제
+
+        do {
+            try context.save() // CoreData에 반영
+            print("✅ Reminder 삭제 성공")
+        } catch {
+            print("❌ CoreData 저장 실패: \(error.localizedDescription)")
+        }
+        if let indexInArray = reminders.firstIndex(of: reminderToDelete) {
+                reminders.remove(at: indexInArray)
+            }
     }
     
-    //MARK: - Inbox View에서 알림 전체 삭제 (알림 자체가 삭제되는 것 아님!)
+    /// Inbox View에서 알림 전체 삭제 (알림 자체가 삭제되는 것 아님!)
     func deleteAllReminders() {
-        for reminder in visibleReminders {
-            reminderRepo.deleteReminder(reminder)
-        }
-        loadAllReminders()
+        let toRemove = visibleReminders
+        
+        toRemove.forEach { reminder in
+                context.delete(reminder) // CoreData에서도 삭제
+            }
+
+            do {
+                try context.save() // CoreData에 반영
+                print("✅ 모든 Reminder 삭제 성공")
+            } catch {
+                print("❌ CoreData 저장 실패: \(error.localizedDescription)")
+            }
+        reminders.removeAll { toRemove.contains($0) }
+
     }
+
+    
+    func deleteRemindersEternally(person: Friend) {
+        
+        let selectedReminders = reminderRepo.fetchReminders(person: person)
+        let ids = Array(reminders).compactMap { $0.id.uuidString }
+        
+        // 1. 예약된 알림 삭제
+        NotificationManager.shared.center.removePendingNotificationRequests(withIdentifiers: ids)
+        NotificationManager.shared.center.removeDeliveredNotifications(withIdentifiers: ids)
+           print("🗑️ 스케줄된 알림 삭제: \(ids)")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            NotificationManager.shared.center.getPendingNotificationRequests { requests in
+                print("남아 있는 스케줄알람 개수: \(requests.count)")
+            }
+        }
+           
+       // 2. CoreData Reminder 삭제
+       for reminder in selectedReminders {
+           context.delete(reminder)
+       }
+        do {
+            try context.save() // CoreData에서 삭제 반영
+            print("✅ \(person.name)의 Reminder 삭제 성공")
+        } catch {
+            print("❌ Reminder 삭제 실패: \(error.localizedDescription)")
+        }
+        
+        DispatchQueue.main.async {
+            self.reminders.removeAll { reminder in
+                selectedReminders.contains(reminder)
+            }
+        }
+    }
+
     
     // MARK: - 알림에 연결된 사람 가지고 오고 해당 프로필 상세로 내비게이션 경로 설정
-    func navigateFromNotification(_ response: UNNotificationResponse) {
-        let userInfo = response.notification.request.content.userInfo
-        print("알림 수신: \(userInfo)")
-        
+    func navigateFromNotification(userInfo: [AnyHashable: Any]) {
+
         guard let person = reminderRepo.fetchPerson(from: userInfo) else { return }
         
         DispatchQueue.main.async {
@@ -61,9 +120,21 @@ class NotificationViewModel: ObservableObject {
     }
     
     // MARK: - 알림 읽음 설정
-    func markAsRead(_ reminder: ReminderEntity) {
+    func isRead(_ reminder: ReminderEntity) {
         reminderRepo.markAsRead(reminder)
         loadAllReminders()
+    }
+    
+    func isTriggered(reminderId: UUID) {
+        
+        let request: NSFetchRequest<ReminderEntity> = ReminderEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", reminderId as CVarArg)
+        if let reminder = try? context.fetch(request).first {
+            reminderRepo.markAsTriggered(reminder)
+        }
+       
+        loadAllReminders()
+        
     }
     
     // MARK: - 새로운 알림 구독 (디버깅 목적)
@@ -85,7 +156,7 @@ class NotificationViewModel: ObservableObject {
     }
     
      // MARK: - 친구 목록을 순회하며 전체 안부 알림 설정
-    func scheduleAnbu(people: [Friend]) {
+    func scheduleNotifications(people: [Friend]) {
          // 1. 내부 알림 설정 체크
 //        guard UserDefaults.standard.bool(forKey: "isNotificationOn") else {
 //            print("🛑 알림 꺼져 있어서 일반 알림 예약 안 함")
@@ -102,19 +173,25 @@ class NotificationViewModel: ObservableObject {
 //                print("❌ 친구에 연결된 PersonEntity 없음")
 //                return
 //            }
-
-            guard let (content, trigger, scheduledDate, personId) = setAnbu(person: friend) else {
+            if (friend.birthDay != nil) {
+                setBDayReminder(person: friend)
+            }
+                
+            if (friend.anniversary != nil) {
+                setAnniversaryReminder(person: friend)
+            }
+            
+            guard let (content, trigger, scheduledDate, reminderId) = setAnbu(person: friend) else {
                 print("❌ 알림 생성 실패")
                 return
             }
             
-            let genRequest = UNNotificationRequest(identifier: personId.uuidString, content: content, trigger: trigger)
+            let genRequest = UNNotificationRequest(identifier: reminderId.uuidString, content: content, trigger: trigger)
             
-            let center = UNUserNotificationCenter.current()
-            center.add(genRequest)
+            NotificationManager.shared.center.add(genRequest)
             
              // person entity 찾기
-            reminderRepo.addReminder(person: friend, type: NotificationType.regular, scheduledDate: scheduledDate)
+            reminderRepo.addReminder(person: friend, reminderId: reminderId, type: NotificationType.regular, scheduledDate: scheduledDate)
             try? context.save()
              // 2. 백엔드에 전송
             guard let token = TokenManager.shared.get(for: .server) else {
@@ -140,22 +217,27 @@ class NotificationViewModel: ObservableObject {
     
      // MARK: - 친구 개개인당 안부 알림 설정
     func setAnbu(person: Friend) -> (content: UNMutableNotificationContent, trigger: UNNotificationTrigger, scheduledDate: Date, id : UUID)? {
+        
+        let reminderID = UUID()
         let calendar = Calendar.current
         let now = Date()
-        
+
         guard let frequency = CheckInFrequency(rawValue: person.frequency?.rawValue ?? CheckInFrequency.none.rawValue), let nextDate = now.nextCheckInDateValue(for: frequency)  else {
             
             print("❌ 잘못된 리마인더 주기")
             return nil
         }
-//
-//        var dateComponents = calendar.dateComponents([.year, .month, .day], from: nextDate)
-//        dateComponents.hour = 23
-//        dateComponents.minute = 32
-//        guard let scheduledDate = calendar.date(from: dateComponents) else { return nil }
-//
-        let future = Calendar.current.date(byAdding: .minute, value: 1, to: Date())!
-        let dateComponents = Calendar.current.dateComponents([.hour, .minute], from: future)
+        
+        var dateComponents = calendar.dateComponents([.year, .month, .day], from: nextDate)
+        dateComponents.hour = 9
+        dateComponents.minute = 0
+
+        if frequency == .daily {
+            let future = Calendar.current.date(byAdding: .second, value: 20, to: Date())!
+            dateComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: future)
+        }
+
+        
         guard let scheduledDate = calendar.date(from: dateComponents) else { return nil }
 
         
@@ -164,23 +246,25 @@ class NotificationViewModel: ObservableObject {
         content.body = "\(person.name)님에게 연락해보세요!"
         content.sound = .default
         content.badge = 1
-        content.userInfo = ["personID": person.id.uuidString, "type": "regular"]
+        content.userInfo = ["personID": person.id.uuidString, "reminderID" : reminderID.uuidString, "type": "regular"]
         
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
         
         print("🟢 [NotificationViewModel] \(person.name) 알림 등록 완료")
-        // ✅ 등록된 알림 확인 로그
-            UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
+        // ✅ 등록된 알림 확인 로그 TODO 나중에 삭제
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            NotificationManager.shared.center.getPendingNotificationRequests { requests in
                 for req in requests {
                     print("🧾 예약된 알림: \(req.identifier), trigger: \(req.trigger!)")
                 }
             }
-        return (content, trigger, scheduledDate, person.id)
+        }
+        return (content, trigger, scheduledDate, reminderID)
     }
     
     
      // MARK: - 프로필 상세 수정뷰에서 친구 별 생일 혹은 기념일 설정
-    func setSpecialReminder(person: Friend, id: String) {
+    func setBDayReminder(person: Friend) {
         
 //        guard UserDefaults.standard.bool(forKey: "isNotificationOn") else {
 //            print("🛑 알림 꺼져 있어서 일반 알림 예약 안 함")
@@ -188,65 +272,115 @@ class NotificationViewModel: ObservableObject {
 //        }
         
         NotificationManager.shared.requestPermissionIfNeeded()
-        
-        let center = UNUserNotificationCenter.current()
         let calendar = Calendar.current
+        let birthdayId = UUID()
         
         if let birthday = person.birthDay,
            let adjustedBday = Date.nextSpecialDate(from: birthday) {
-           
+        
+            var birthdayComponents = calendar.dateComponents([.year, .month, .day], from: adjustedBday)
+            birthdayComponents.hour = 1
+            birthdayComponents.minute = 54
+            
+            guard let scheduledDate = calendar.date(from: birthdayComponents) else {
+                print("❌ 생일 날짜 생성 실패")
+                return }
+
+            reminderRepo.addReminder(person: person, reminderId: birthdayId, type: NotificationType.birthday, scheduledDate: scheduledDate)
+            
             let content = UNMutableNotificationContent()
             content.title = "🎂 생일 알림"
             content.body = "\(person.name)님의 생일이에요! 연락해보세요!"
             content.sound = .default
             content.badge = 1
+            content.userInfo = ["personID": person.id.uuidString, "reminderID": birthdayId.uuidString, "type": "birthday"]
             
-            var birthdayComponents = calendar.dateComponents([.year, .month, .day], from: adjustedBday)
-            birthdayComponents.hour = 8
-            birthdayComponents.minute = 0
-            
-            guard let scheduledDate = calendar.date(from: birthdayComponents) else {
-                print("❌ 생일 날짜 생성 실패")
-                return
-            }
+            print("🟢 [NotificationViewModel] \(person.name)의 생일 알림 등록 완료")
 
-            reminderRepo.addReminder(person: person, type: NotificationType.birthday, scheduledDate: scheduledDate)
-            
-            content.userInfo = ["personID": "\(id)", "type": "birthday"]
-            
             try? context.save()
             
             let trigger = UNCalendarNotificationTrigger(dateMatching: birthdayComponents, repeats: true)
             
-            let bdayRequest = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
-            center.add(bdayRequest)
-        }
+            let bdayRequest = UNNotificationRequest(identifier: birthdayId.uuidString, content: content, trigger: trigger)
             
-            if let anniversary = person.anniversary?.Date,
-                let adjustedAnniversary = Date.nextSpecialDate(from: anniversary) {
-                let content = UNMutableNotificationContent()
-                content.title = "💖 기념일 알림"
-                content.body = "\(person.name)님과의 기념일이에요! 연락해보세요!"
-                content.sound = .default
-                content.badge = 1
-                
-                var anniversaryComponents = calendar.dateComponents([.year, .month, .day], from: adjustedAnniversary)
-                anniversaryComponents.hour = 08
-                anniversaryComponents.minute = 00
-                
-                guard let scheduledDate = calendar.date(from: anniversaryComponents) else { return }
-                
-                reminderRepo.addReminder(person: person, type: NotificationType.anniversary
-                                         , scheduledDate: scheduledDate)
-                
-                content.userInfo = ["personID": "\(id)", "type": "anniversary"]
-                
-                try? context.save()
-                
-                let trigger = UNCalendarNotificationTrigger(dateMatching: anniversaryComponents, repeats: true)
-                let anniRequest = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
-                center.add(anniRequest)
+            NotificationManager.shared.center.add(bdayRequest) { error in
+                if let error = error {
+                    print("🔴 생일 알림 등록 실패: \(error.localizedDescription)")
+                } else {
+                    print("🟢 생일 알림 등록 성공: \(bdayRequest.identifier)")
+                }
             }
+            
+            guard let token = TokenManager.shared.get(for: .server) else {
+                print("⚠️ 서버 accessToken 없음 - 백엔드 요청 생략")
+                return
+            }
+            
+            BackEndAuthService.shared.sendReminder(friendId: person.id, accessToken: token) { result in
+                switch result {
+                case .success:
+                    print("📬 리마인더 서버 전송 완료")
+                case .failure(let error):
+                    print("📭 리마인더 서버 전송 실패: \(error)")
+                }
+            }
+        }
+    }
+    
+    func setAnniversaryReminder(person: Friend) {
+        
+        NotificationManager.shared.requestPermissionIfNeeded()
+        let calendar = Calendar.current
+        let anniversaryId = UUID()
+        
+        if let anniversary = person.anniversary?.Date,
+            let adjustedAnniversary = Date.nextSpecialDate(from: anniversary) {
+            
+            var anniversaryComponents = calendar.dateComponents([.year, .month, .day], from: adjustedAnniversary)
+            anniversaryComponents.hour = 08
+            anniversaryComponents.minute = 00
+            
+            guard let scheduledDate = calendar.date(from: anniversaryComponents) else {
+                print("🔴 기념일 날짜 생성 실패")
+                return }
+            
+            reminderRepo.addReminder(person: person, reminderId: anniversaryId, type: NotificationType.anniversary, scheduledDate: scheduledDate)
+            
+            let content = UNMutableNotificationContent()
+            content.title = "💖 기념일 알림"
+            content.body = "\(person.name)님과의 기념일이에요! 연락해보세요!"
+            content.sound = .default
+            content.badge = 1
+            
+            content.userInfo = ["personID": person.id.uuidString, "reminderID": anniversaryId.uuidString, "type": "anniversary"]
+           
+            print("🟢 [NotificationViewModel] \(person.name)의 기념일 알림 등록 완료")
+            try? context.save()
+                
+            let trigger = UNCalendarNotificationTrigger(dateMatching: anniversaryComponents, repeats: true)
+            let anniRequest = UNNotificationRequest(identifier: anniversaryId.uuidString, content: content, trigger: trigger)
+            NotificationManager.shared.center.add(anniRequest) { error in
+                if let error = error {
+                    print("🔴 기념일 알림 등록 실패: \(error.localizedDescription)")
+                } else {
+                    print("🟢 기념일 알림 등록 성공: \(anniRequest.identifier)")
+                }
+            }
+            guard let token = TokenManager.shared.get(for: .server) else {
+                print("⚠️ 서버 accessToken 없음 - 백엔드 요청 생략")
+                return
+            }
+            
+            BackEndAuthService.shared.sendReminder(friendId: person.id, accessToken: token) { result in
+                switch result {
+                case .success:
+                    print("📬 리마인더 서버 전송 완료")
+                case .failure(let error):
+                    print("📭 리마인더 서버 전송 실패: \(error)")
+                }
+            }
+            
+        }
         }
     }
 
@@ -255,8 +389,7 @@ extension NotificationViewModel {
     var visibleReminders: [ReminderEntity] {
         let today = Calendar.current.startOfDay(for: Date())
         return reminders
-                .filter { Calendar.current.startOfDay(for: $0.date) <= today }
-                    .sorted(by: { $0.date > $1.date })
+            .filter { $0.isTriggered }
+            .sorted(by: { $0.date > $1.date })
     }
 }
-

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -23,7 +23,7 @@ public struct HomeView: View {
                     VStack {
                         VStack(spacing: 24) {
                             // 네비게이션 바
-                            CustomNavigationBar(badgeCount: notificationViewModel.badgeCount,
+                            CustomNavigationBar(showBadge: notificationViewModel.showBadge,
                                                 onTapMy: {DispatchQueue.main.async {
                                 path.append(.my)} },
                                                 onTapBell: { DispatchQueue.main.async { path.append(.inbox) }
@@ -61,7 +61,7 @@ public struct HomeView: View {
 // MARK: - 커스텀 네비게이션 바
 struct CustomNavigationBar: View {
     
-    let badgeCount: Int
+    let showBadge: Bool
     let onTapMy: () -> Void
     let onTapBell: () -> Void
     
@@ -79,7 +79,7 @@ struct CustomNavigationBar: View {
                 Button {
                     onTapBell()
                 } label: {
-                    if badgeCount > 0 {
+                    if showBadge {
                         Button(action: onTapBell) {
                             Image(systemName: "bell.badge.fill")
                                 .foregroundStyle(Color.white)
@@ -165,7 +165,7 @@ struct ThisMonthSection: View {
                     HStack(spacing: 12) {
                         ForEach(peoples, id: \.id) { contact in
                             ThisMonthContactCell(contact: contact) { selected in
-                                // TODO: 상세 네비게이션 연결
+                                // TODO: 상세 네비게이션 연결 -> 이거 지금 어떻게 연결 되고 있는 걸까요 ㅋㅋ
                                 print("\(selected.name) tapped")
                             }
                         }
@@ -319,10 +319,7 @@ struct MyPeopleSection: View {
                         TabView(selection: $currentPage) {
                             ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
                                 StarPositionLayout(peoples: $peoples , pageIndex: index) { selected in
-                                    // TODO: - 친구 상세 뷰 이동
                                     path.append(.personDetail(selected))
-                                    print("\(selected.name) tapped")
-                                    print("\(selected.id) tapped")
                                 }
                                 .tag(index)
                             }

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
@@ -2,11 +2,12 @@ import SwiftUI
 
 struct ProfileDetailView: View {
     @ObservedObject var viewModel: ProfileDetailViewModel
+    @ObservedObject var notificationViewModel: NotificationViewModel
     @Binding var path: [AppRoute]
     @State private var selectedTab: Tab = .profile
     @State private var showActionSheet = false
     @State private var isEditing = false
-
+    
     enum Tab {
         case profile, records
     }
@@ -81,6 +82,10 @@ struct ProfileDetailView: View {
                     }
                     Button("삭제", role: .destructive) {
                         viewModel.deleteFriend(friendId: viewModel.people.id) {
+//                            print("삭제 버튼 클릭 됨")
+//                            print("❌ 리마인드 삭제")
+                            notificationViewModel.deleteRemindersEternally(person: viewModel.people)
+//                            print("❌ 리마인드 삭제")
                             DispatchQueue.main.async {
                                 path.removeAll()
                             }
@@ -480,41 +485,38 @@ private struct ConfirmButton: View {
     }
 }
 
-
-struct ProfileDetailView_Previews: PreviewProvider {
-    static var previews: some View {
-        Group {
-            previewForDevice("iPhone 13 mini")
-            previewForDevice("iPhone 16")
-            previewForDevice("iPhone 16 Pro")
-            previewForDevice("iPhone 16 Pro Max")
-        }
-    }
-    
-    static func previewForDevice(_ deviceName: String) -> some View {
-        ProfileDetailView(
-            viewModel: ProfileDetailViewModel(
-                people: Friend(
-                    id: UUID(),
-                    name: "임시 친구",
-                    image: nil,
-                    imageURL: nil,
-                    source: .kakao,
-                    frequency: .monthly,
-                    phoneNumber: "010-1234-5678",
-                    relationship: "동료",
-                    birthDay: Date(),
-                    anniversary: AnniversaryModel(title: "결혼기념일", Date: Date()),
-//                    memo: "Lorem ipsum dolor sit amet consectetur adipiscing elit quisque faucibus ex sapien vitae pellentesque",
-                    memo: "",
-                    nextContactAt: Date().addingTimeInterval(86400 * 30),
-                    lastContactAt: Date().addingTimeInterval(-86400 * 10),
-                    checkRate: 75,
-                    position: 0,
-                    fileName: ".jpg")
-            ), path: .constant([])
-        )
-    }
-}
-
-
+//struct ProfileDetailView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        Group {
+//            previewForDevice("iPhone 13 mini")
+//            previewForDevice("iPhone 16")
+//            previewForDevice("iPhone 16 Pro")
+//            previewForDevice("iPhone 16 Pro Max")
+//        }
+//    }
+//    
+//    static func previewForDevice(_ deviceName: String) -> some View {
+//        ProfileDetailView(
+//            viewModel: ProfileDetailViewModel(
+//                people: Friend(
+//                    id: UUID(),
+//                    name: "임시 친구",
+//                    image: nil,
+//                    imageURL: nil,
+//                    source: .kakao,
+//                    frequency: .monthly,
+//                    phoneNumber: "010-1234-5678",
+//                    relationship: "동료",
+//                    birthDay: Date(),
+//                    anniversary: AnniversaryModel(title: "결혼기념일", Date: Date()),
+////                    memo: "Lorem ipsum dolor sit amet consectetur adipiscing elit quisque faucibus ex sapien vitae pellentesque",
+//                    memo: "",
+//                    nextContactAt: Date().addingTimeInterval(86400 * 30),
+//                    lastContactAt: Date().addingTimeInterval(-86400 * 10),
+//                    checkRate: 75,
+//                    position: 0,
+//                    fileName: ".jpg")
+//            ), path: .constant([])
+//        )
+//    }
+//}

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -126,7 +126,6 @@ struct ContactFrequencySettingsView: View {
                         DispatchQueue.main.async {
                             viewModel.uploadAllFriendsToServer(viewModel.people) {
                                 UserSession.shared.user?.friends = viewModel.people
-                                notificationViewModel.scheduleAnbu(people: UserSession.shared.user?.friends ?? [])
                                 complete(viewModel.people)
                             }
                         }

--- a/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
+++ b/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
@@ -16,7 +16,7 @@ struct NotificationInboxView: View {
 
     private var bodyView: some View {
         VStack {
-            if notificationViewModel.reminders.isEmpty {
+            if notificationViewModel.visibleReminders.isEmpty {
                 Text("오늘 예정된 알림이 없어요!")
                     .foregroundColor(.gray)
                     .padding()
@@ -40,15 +40,14 @@ struct ReminderListView: View {
     
     var body: some View {
         List {
-            ForEach(notificationViewModel.reminders, id: \.self) { reminder in
+            ForEach(notificationViewModel.visibleReminders, id: \.self) { reminder in
                 ReminderRowView(notificationViewModel: notificationViewModel,
                                 reminder: reminder,
                                 person: reminder.person,
                                 onSelect: { person in
                     
-                    var friend = UserSession.shared.user?.friends.filter({$0.id == person.id}).first
-                    
-                    friend?.initEntity(from: person)
+                    let friend = UserSession.shared.user?.friends.filter({$0.id == person.id}).first
+                    // friend.id == person.id 비교해야할까요?
                     if let friend = friend {
                         path.append(.personDetail(friend))
                     }
@@ -70,7 +69,7 @@ struct ReminderRowView: View {
     var body: some View {
         ReminderContent(person: person, reminder: reminder)
             .onTapGesture {
-                notificationViewModel.markAsRead(reminder)
+                notificationViewModel.isRead(reminder)
                 onSelect(person)
             }
             .background(NavigationLink(value: person) {


### PR DESCRIPTION
## ✨ 변경 사항 요약
- contact Frequency setting 할 때 안부와 기념일, 생일 알림 저장될 수 있도록 알림 기능 구현

## 📄 작업 내용 상세 설명
- personEntity와 friend는 서로 독립적으로 작용하되 id가 동일해서 서로를 찾을 수 있게 구현했습니다
- reminderIds는 person.id가 아닌 UUID입니다.
- inbox View에서는 isTrigger == true인 알림들만 날짜별로 소팅 되어 보여집니다.
- 프로필 삭제 시 인물에 종속된 모든 알림과 inbox뷰에 띄워졌던 알림들도 삭제 됩니다.
- badgeCount가 원래는 int였는데 숫자가 필요 없어서 booleand으로 업데이트 했습니다

### 🎯 작업 목적
- contact Frequency setting 할 때 안부와 기념일, 생일 알림 저장될 수 있도록 알림 기능 구현
- **시연 목적으로 contact Frequency 설정 시 "매일"을 클릭하면 20분 뒤로 알림이 옵니다!** 

### 🛠️ 주요 변경 사항

### 📸 스크린샷 (필요시 추가)
![ScreenRecording2025-04-29at2 15 27AM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6b0592c7-ca3f-42e6-a2b9-be45f064d58a)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 알림을 클릭 했을 때 유저 상세 프로필로 가지 않습니다
- contact에 오늘 생일인 사람을 만들어서 1분 뒤에 알림이 올 수 있도록 테스트를 했는데 nw_connection_add_timestamp_locked_on_nw_queue [C3] Hit maximum timestamp count, will start dropping events 라면서 알림이 스케줄 되지 않습니다.. 좀 더 디버깅 해봐야하는 부분일 것 같아요.
- 앱 뱃지가 1로 설정 되어서 없어지지가 않습니다. 왜 이러는지 모르겠어요.. 이슈로 등록해놓겠습니다.
- 홈에서 인박스 이동 bell이 bell.filled로 inbox view로 이동했다 돌아와야 업데이트가 됩니다.

### ✅ 참고 이슈 및 관련 작업
- #68 
- #70 
- #66 
- #65 