### PR TITLE
[FIX] Date 한국시간대 적용, 친구 상세 수정 적용 이슈 해결

### DIFF
--- a/SwypApp2nd/Sources/Common/Date+Extension.swift
+++ b/SwypApp2nd/Sources/Common/Date+Extension.swift
@@ -3,7 +3,9 @@ import Foundation
 extension Date {
     /// 주기 설정의 다음주기 M/d EEE
     func nextCheckInDate(for frequency: CheckInFrequency) -> String {
-        let calendar = Calendar.current
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         var nextDate: Date?
 
         switch frequency {
@@ -24,6 +26,7 @@ extension Date {
         guard let date = nextDate else { return "-" }
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         formatter.dateFormat = "M/d EEE"
 
         return formatter.string(from: date)
@@ -31,7 +34,9 @@ extension Date {
     
     /// 주기 설정의 다음주기의 요일 반환 EEEE
     func nextCheckInDateDayOfTheWeek(for frequency: CheckInFrequency) -> String {
-        let calendar = Calendar.current
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         var nextDate: Date?
 
         switch frequency {
@@ -52,13 +57,16 @@ extension Date {
         guard let date = nextDate else { return "-" }
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         formatter.dateFormat = "EEEE"
 
         return formatter.string(from: date)
     }
 
     func nextCheckInDateValue(for frequency: CheckInFrequency) -> Date? {
-        let calendar = Calendar.current
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         switch frequency {
         case .daily:
             return calendar.date(byAdding: .day, value: 1, to: self)
@@ -77,7 +85,9 @@ extension Date {
     
     static func nextSpecialDate(from baseDate: Date?) -> Date? {
         guard let baseDate else { return nil }
-        let calendar = Calendar.current
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         let now = Date()
         
         let month = calendar.component(.month, from: baseDate)
@@ -95,6 +105,7 @@ extension Date {
     func weekdayKorean() -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         formatter.dateFormat = "EEEE"
         return formatter.string(from: self)
     }
@@ -109,9 +120,9 @@ extension Date {
     
     func formattedYYYYMMDDWithDot() -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
         formatter.locale = Locale(identifier: "ko_KR")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        formatter.dateFormat = "yyyy.MM.dd"
         return formatter.string(from: self)
     }
     
@@ -119,7 +130,7 @@ extension Date {
         let formatter = DateFormatter()
         formatter.dateFormat = "yy.MM.dd"
         formatter.locale = Locale(identifier: "ko_KR")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         return formatter.string(from: self)
     }
     
@@ -127,8 +138,18 @@ extension Date {
         let formatter = DateFormatter()
         formatter.dateFormat = "M월 dd일 더 가까워졌어요"
         formatter.locale = Locale(identifier: "ko_KR")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         return formatter.string(from: self)
     }
-
+    
+    func startOfDayInKorea() -> Date {
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+        let components = calendar.dateComponents(
+            [.year, .month, .day],
+            from: self
+        )
+        return calendar.date(from: components) ?? self
+    }
 }

--- a/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/ProfileDetail/ProfileDetailViewModel.swift
@@ -5,10 +5,13 @@ class ProfileDetailViewModel: ObservableObject {
     @Published var checkInRecords: [CheckInRecord] = []
     
     var canCheckInToday: Bool {
+        guard let kstTimeZone = TimeZone(identifier: "Asia/Seoul") else {
+            fatalError("Could not load KST time zone")
+        }
         var calendar = Calendar.current
-        calendar.timeZone = TimeZone(abbreviation: "UTC")!
+        calendar.timeZone = kstTimeZone
 
-        let today = calendar.startOfDay(for: Date())
+        let today = calendar.startOfDay(for: .now)
 
         return !checkInRecords.contains { record in
             let recordDate = calendar.startOfDay(for: record.createdAt)

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -225,13 +225,15 @@ struct ThisMonthContactCell: View {
 
     var dDayString: String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         formatter.dateFormat = "yyyy-MM-dd"
         guard let target = formatter.date(from: contact.nextContactAt) else {
             return ""
         }
             
-        let today = Calendar.current.startOfDay(for: Date())
-        let targetDay = Calendar.current.startOfDay(for: target)
+        let today = Calendar.current.startOfDay(for: Date().startOfDayInKorea())
+        let targetDay = Calendar.current.startOfDay(for: target.startOfDayInKorea())
         let diff = Calendar.current.dateComponents(
             [.day],
             from: today,

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
@@ -50,6 +50,10 @@ struct ProfileDetailView: View {
         }
         .padding(.horizontal, 24)
         .navigationBarBackButtonHidden()
+        .onAppear {
+            viewModel.fetchFriendDetail(friendId: viewModel.people.id)
+            viewModel.fetchFriendRecords(friendId: viewModel.people.id)
+        }
         .toolbar {
             ToolbarItem(placement: .topBarLeading)  {
                 Button(action: {
@@ -93,13 +97,15 @@ struct ProfileDetailView: View {
                     }
                     Button("취소", role: .cancel) {}
                 }
-                .fullScreenCover(isPresented: $isEditing) {
+        .fullScreenCover(isPresented: $isEditing) {
             NavigationStack {
+                let profileEditViewModel = ProfileEditViewModel(person: viewModel.people)
                 ProfileEditView(
-                    profileEditViewModel: ProfileEditViewModel(person: viewModel.people)) {
+                    profileEditViewModel: profileEditViewModel) {
                         viewModel.fetchFriendDetail(friendId: viewModel.people.id)
+                        viewModel.people = profileEditViewModel.person
                         isEditing = false
-                }
+                    }
             }
         }
     }
@@ -395,13 +401,6 @@ private struct ProfileInfoSection: View {
             InfoRow(label: "기념일", value: "\(people.anniversary?.title ?? "-") (\(people.anniversary?.Date?.formattedYYYYMMDDWithDot() ?? "-"))")
             MemoRow(label: "메모", value: people.memo ?? "-")
         }
-    }
-
-    private func formatDate(_ date: Date?) -> String {
-        guard let date = date else { return "-" }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
-        return formatter.string(from: date)
     }
     
     private func displayLabel(for rawValue: String?) -> String? {

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileEditView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileEditView.swift
@@ -219,7 +219,7 @@ struct BirthdaySection: View {
                     "",
                     selection: Binding(
                         get: { birthday ?? Date() },
-                        set: { birthday = $0 }
+                        set: { birthday = $0.startOfDayInKorea() }
                     ),
                     displayedComponents: .date
                 )
@@ -234,6 +234,7 @@ struct BirthdaySection: View {
     private func formattedDate(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         formatter.dateFormat = "yyyy년 M월 d일"
         return formatter.string(from: date)
     }
@@ -302,9 +303,9 @@ struct AnniversarySection: View {
                         get: { anniversary?.Date ?? Date() },
                         set: { newValue in
                             if anniversary == nil {
-                                anniversary = AnniversaryModel(title: "", Date: newValue)
+                                anniversary = AnniversaryModel(title: "", Date: newValue.startOfDayInKorea())
                             } else {
-                                anniversary?.Date = newValue
+                                anniversary?.Date = newValue.startOfDayInKorea()
                             }
                         }
                     ),
@@ -393,7 +394,7 @@ struct WheelDatePicker: View {
                     "",
                     selection: Binding(
                         get: { date ?? Date() },
-                        set: { date = $0 }
+                        set: { date = $0.startOfDayInKorea() }
                     ),
                     in: dateRange,
                     displayedComponents: .date
@@ -416,6 +417,7 @@ struct WheelDatePicker: View {
     private func formattedDate(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         formatter.dateFormat = "yyyy년 M월 d일"
         return formatter.string(from: date)
     }

--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -15,22 +15,47 @@ struct MyProfileView: View {
     
     @StateObject var myViewModel =  MyViewModel()
     @StateObject var termsViewModel = TermsViewModel()
-    var user = UserSession.shared.user!
+    var user: User? {
+        UserSession.shared.user
+    }
     
     var body: some View {
         NavigationView {
             VStack(spacing: 20) {
-                UserProfileSectionView(name: user.name, profilePic: user.profileImageURL)
-                AccountSettingSectionView(loginType: user.loginType)
-                NotificationSettingsView(viewModel: myViewModel)
-                SimpleTermsView(termsViewModel: termsViewModel)
-                WithdrawalButtonView (
-                    loginType: user.loginType,
-                    onWithdrawTap: {
-                        showWithdrawalSheet = true
-                    },
-                    path: $path
-                )
+                if let user = UserSession.shared.user {
+                    NavigationView {
+                        VStack(spacing: 20) {
+                            UserProfileSectionView(
+                                name: user.name,
+                                profilePic: user.profileImageURL
+                            )
+                            AccountSettingSectionView(loginType: user.loginType)
+                            NotificationSettingsView(viewModel: myViewModel)
+                            SimpleTermsView(termsViewModel: termsViewModel)
+                            WithdrawalButtonView (
+                                loginType: user.loginType,
+                                onWithdrawTap: {
+                                    showWithdrawalSheet = true
+                                },
+                                path: $path
+                            )
+                        }
+                        .fullScreenCover(isPresented: $showWithdrawalSheet) {
+                            WithdrawalView(path: $path)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                } else {
+                    ProgressView()
+                        .onAppear {
+                            DispatchQueue.main.async {
+                                if path.last == .my { 
+                                    path.removeLast()
+                                }
+                            }
+                        }
+                }
+                
             }
             .fullScreenCover(isPresented: $showWithdrawalSheet) {
                 WithdrawalView(path: $path)
@@ -211,14 +236,18 @@ struct WithdrawalButtonView: View {
                 if loginType == .kakao {
                     UserSession.shared.kakaoLogout{ success in
                         if success {
-                            path.removeLast()
+                            DispatchQueue.main.async {
+                                path.removeLast()
+                            }
                         }
                     }
                 }
                 else {
                     UserSession.shared.appleLogout{ success in
                         if success {
-                            path.removeLast()
+                            DispatchQueue.main.async {
+                                path.removeLast()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 날짜 포맷 및 시간대 관련 버그 수정 (Asia/Seoul 반영)
- ProfileEditView 수정 사항이 DetailView에 즉시 반영되지 않는 문제 해결

## 📄 작업 내용 상세 설명
- Date extension 내 포맷 함수들(formattedYYYYMMDDWithDot, formattedYYMMDDWithDot 등)에 Asia/Seoul 시간대를 정확히 지정하여 KST 기준으로 날짜 출력되도록 수정
- startOfDayInKorea() 유틸 메서드를 도입하여 날짜 비교 및 DatePicker 선택값의 시간 오차 이슈 해결
- ProfileEditView에서 수정 완료 시, onComplete에서 다시 서버로부터 최신 정보를 fetch 하도록 개선

### 🎯 작업 목적
- 생일/기념일 날짜가 하루 전으로 표시되는 이슈 해결
- 사용자 정보 수정 후 HomeView로 돌아가지 않고도 바로 반영된 결과 확인 가능하게 개선

### 🛠️ 주요 변경 사항
- Date+Extension.swift : TimeZone 관련 수정 및 startOfDayInKorea() 메서드 추가
- ProfileEditView.swift, ProfileDetailView.swift : 프로필 수정 후 최신 데이터 fetch 로직 수정

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- DatePicker나 Date 포맷 관련 로직은 모두 Asia/Seoul 기준으로 통일됨 추후 Localization시 Date 수정 필요
- 타 기능에서도 startOfDay 비교 시 startOfDayInKorea() 사용 권장

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #84 ,#85, #92, #86