### PR TITLE
[Feature] 챙김률에 따른 메시지 적용, 친구 순서 변경 적용

### DIFF
--- a/SwypApp2nd/Sources/GlobalState/UserSession.swift
+++ b/SwypApp2nd/Sources/GlobalState/UserSession.swift
@@ -112,15 +112,20 @@ class UserSession: ObservableObject {
                         print(
                             "🟢 [UserSession] fetchMemberInfo 성공 - 닉네임: \(info.nickname)"
                         )
-                        let user = User(
-                            id: info.memberId,
-                            name: info.nickname,
-                            friends: [],
-                            loginType: .kakao,
-                            serverAccessToken: accessToken,
-                            serverRefreshToken: TokenManager.shared.get(for: .server, isRefresh: true) ?? "" // TODO: - refresh토큰 재발급
-                        )
-                        self.updateUser(user)
+                        
+                        self.getUserCheckRate(accessToken: accessToken) { checkRate in
+                            let user = User(
+                                id: info.memberId,
+                                name: info.nickname,
+                                friends: [],
+                                checkRate: checkRate,
+                                loginType: .kakao,
+                                serverAccessToken: accessToken,
+                                serverRefreshToken: TokenManager.shared
+                                    .get(for: .server, isRefresh: true) ?? ""
+                            )
+                            self.updateUser(user)
+                        }
                     case .failure(let error):
                         print("🔴 [UserSession] 사용자 정보 조회 실패: \(error)")
                         self.logout()
@@ -152,15 +157,18 @@ class UserSession: ObservableObject {
                             BackEndAuthService.shared.fetchMemberInfo(accessToken: newAccessToken) { result in
                                 switch result {
                                 case .success(let info):
-                                    let user = User(
-                                        id: info.memberId,
-                                        name: info.nickname,
-                                        friends: [],
-                                        loginType: .kakao,
-                                        serverAccessToken: newAccessToken,
-                                        serverRefreshToken: refreshToken
-                                    )
-                                    self.updateUser(user)
+                                    self.getUserCheckRate(accessToken: newAccessToken) { checkRate in
+                                        let user = User(
+                                            id: info.memberId,
+                                            name: info.nickname,
+                                            friends: [],
+                                            checkRate: checkRate,
+                                            loginType: .kakao,
+                                            serverAccessToken: newAccessToken,
+                                            serverRefreshToken: refreshToken
+                                        )
+                                        self.updateUser(user)
+                                    }
                                 case .failure(let error):
                                     print(
                                         "🔴 [UserSession] 사용자 정보 조회 실패: \(error)"
@@ -199,16 +207,21 @@ class UserSession: ObservableObject {
                     print(
                         "🟢 [UserSession] fetchMemberInfo 성공 - 닉네임: \(info.nickname)"
                     )
-                    let user = User(
-                        id: info.memberId,
-                        name: info.nickname,
-                        friends: [],
-                        loginType: .apple,
-                        serverAccessToken: accessToken,
-                        serverRefreshToken: TokenManager.shared
-                            .get(for: .server, isRefresh: true) ?? ""
-                    )
-                    self.updateUser(user)
+                    
+                    self.getUserCheckRate(accessToken: accessToken) { checkRate in
+                        let user = User(
+                            id: info.memberId,
+                            name: info.nickname,
+                            friends: [],
+                            checkRate: checkRate,
+                            loginType: .apple,
+                            serverAccessToken: accessToken,
+                            serverRefreshToken: TokenManager.shared
+                                .get(for: .server, isRefresh: true) ?? ""
+                        )
+                        self.updateUser(user)
+                    }
+                    
                 case .failure(let error):
                     print("🔴 [UserSession] 사용자 정보 조회 실패: \(error)")
                     self.logout()
@@ -239,15 +252,20 @@ class UserSession: ObservableObject {
                         ) { result in
                             switch result {
                             case .success(let info):
-                                let user = User(
-                                    id: info.memberId,
-                                    name: info.nickname,
-                                    friends: [],
-                                    loginType: .apple,
-                                    serverAccessToken: newAccessToken,
-                                    serverRefreshToken: refreshToken
-                                )
-                                self.updateUser(user)
+                                
+                                self.getUserCheckRate(accessToken: newAccessToken) { checkRate in
+                                    let user = User(
+                                        id: info.memberId,
+                                        name: info.nickname,
+                                        friends: [],
+                                        checkRate: checkRate,
+                                        loginType: .apple,
+                                        serverAccessToken: newAccessToken,
+                                        serverRefreshToken: refreshToken
+                                    )
+                                    self.updateUser(user)
+                                }
+                                
                             case .failure(let error):
                                 print("🔴 [UserSession] 사용자 정보 조회 실패: \(error)")
                                 self.logout()
@@ -308,5 +326,21 @@ class UserSession: ObservableObject {
         }
     }
 
-
+    // 유저의 챙김률
+    func getUserCheckRate(accessToken: String, completion: @escaping (Int) -> Void) {
+            
+        BackEndAuthService.shared
+            .getUserCheckRate(accessToken: accessToken) { result in
+                switch result {
+                case .success(let success):
+                    print(
+                        "🟢 [UserSession] getUserCheckRate 성공 챙김률: \(success.checkRate)"
+                    )
+                    completion(success.checkRate)
+                case .failure(let error):
+                    print("🔴 [UserSession] getUserCheckRate 실패: \(error)")
+                    completion(0)
+                }
+            }
+    }
 }

--- a/SwypApp2nd/Sources/Models/User.swift
+++ b/SwypApp2nd/Sources/Models/User.swift
@@ -6,6 +6,7 @@ struct User: Codable, Identifiable {
     var email: String?  // 이메일
     var profileImageURL: String?  // 프로필 사진 URL
     var friends: [Friend] // 챙길 친구들
+    var checkRate: Int? // 체크율
     var loginType: LoginType  // 애플, 카카오
     let serverAccessToken: String // 서버 access token
     let serverRefreshToken: String // 서버 refresh token

--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -164,6 +164,17 @@ struct FriendMonthlyResponse: Codable {
     var nextContactAt: String
 }
 
+// MARK: - 친구 순서 변경
+struct FriendOrderUpdateRequestDTO: Codable {
+    let newPosition: Int
+}
+
+// MARK: - 체크율
+struct FriendCheckRateRespose: Codable {
+    var checkRate: Int
+}
+
+
 // MARK: - 서버 통신 로직
 final class BackEndAuthService {
     static let shared = BackEndAuthService()
@@ -719,6 +730,60 @@ final class BackEndAuthService {
                 }
             }
     }
+    
+    /// 백엔드: 친구 순서 변경
+    func patchFriendOrder(accessToken: String, id: String, newPosition: Int, completion: @escaping (Result<Void, Error>) -> Void) {
+        let url = "\(baseURL)/friend/list/\(id)"
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
+        
+        let requestData = FriendOrderUpdateRequestDTO(newPosition: newPosition)
+        
+        AF.request(
+            url,
+            method: .patch,
+            parameters: requestData,
+            encoder: JSONParameterEncoder.default,
+            headers: headers
+        )
+        .validate(statusCode: 200..<300)
+        .response { response in
+            switch response.result {
+            case .success:
+                print("🟢 [BackEndAuthService] 친구 순서 변경 성공 - id: \(id), newPosition: \(response.result)")
+                completion(.success(()))
+            case .failure(let error):
+                print("🔴 [BackEndAuthService] 친구 순서 변경 실패 - \(error.localizedDescription)")
+                completion(.failure(error))
+            }
+        }
+        
+    }
+    
+    
+    /// 백엔드: (챙김 기록 기반) 체크율
+    func getUserCheckRate(accessToken: String, completion: @escaping (Result<FriendCheckRateRespose, Error>) -> Void) {
+        let url = "\(baseURL)/member/check-rate"
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
+        
+        AF.request(url, method: .get, headers: headers)
+            .validate(statusCode: 200..<300)
+            .responseDecodable(of: FriendCheckRateRespose.self) { response in
+                switch response.result {
+                case .success(let checkRate):
+                    print("🟢 [BackEndAuthService] 친구 챙김율 조회 성공 - \(checkRate)")
+                    completion(.success(checkRate))
+                case .failure(let error):
+                    print("🔴 [BackEndAuthService] 친구 챙김율율 조회 실패 - \(error.localizedDescription)")
+                    completion(.failure(error))
+                }
+            }
+    }
+        
+        
 }
 
 

--- a/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Home/HomeViewModel.swift
@@ -128,4 +128,19 @@ class HomeViewModel: ObservableObject {
             }
         }
     }
+    
+    // 친구 순서 변경
+    func patchFriendOrder(targetID: String, newPosition: Int) {
+        guard let token = UserSession.shared.user?.serverAccessToken else { return }
+        
+        BackEndAuthService.shared.patchFriendOrder(accessToken: token, id: targetID, newPosition: newPosition) { result in
+            switch result {
+            case .success(_):
+                print("🟢 [HomeViewModel] 친구 순서 변경 성공 - id: \(targetID), newPosition: \(newPosition)")
+            case .failure(let error):
+                print("🔴 [HomeViewModel] 친구 순서 변경 실패 - \(error.localizedDescription)")
+            }
+            
+        }
+    }
 }

--- a/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
@@ -37,13 +37,6 @@ class LoginViewModel: ObservableObject {
                     self.isLoading = false
                     switch result {
                     case .success(let tokenResponse):
-                        var user = User(
-                            id: "",
-                            name: "",
-                            friends: [], loginType: .kakao,
-                            serverAccessToken: tokenResponse.accessToken,
-                            serverRefreshToken: tokenResponse.refreshTokenInfo.token
-                        )
                         
                         // 서버 토큰 저장
                         TokenManager.shared
@@ -60,9 +53,18 @@ class LoginViewModel: ObservableObject {
                                 switch result {
                                 case .success(let userInfo):
                                     print("🟢 자동 로그인 성공: \(userInfo.nickname)")
-                                    user.name = userInfo.nickname
-                                    user.id = userInfo.memberId
-                                    self.updateUserSession(with: user)
+                                    self.getUserCheckRate(accessToken: tokenResponse.accessToken) { checkRate in
+                                        let user = User(
+                                            id: userInfo.memberId,
+                                            name: userInfo.nickname,
+                                            friends: [],
+                                            checkRate: checkRate,
+                                            loginType: .kakao,
+                                            serverAccessToken: tokenResponse.accessToken,
+                                            serverRefreshToken: tokenResponse.refreshTokenInfo.token
+                                        )
+                                        self.updateUserSession(with: user)
+                                    }
                                 case .failure(let error):
                                     print("🔴 자동 로그인 실패: \(error)")
                                 }
@@ -102,14 +104,6 @@ class LoginViewModel: ObservableObject {
                         switch result {
                         case .success(let tokenResponse):
                             
-                            var user = User(
-                                id: "",
-                                name: "",
-                                friends: [], loginType: .apple,
-                                serverAccessToken: tokenResponse.accessToken,
-                                serverRefreshToken: tokenResponse.refreshTokenInfo.token
-                            )
-                            
                             TokenManager.shared
                                 .save(
                                     token: tokenResponse.accessToken,
@@ -127,9 +121,18 @@ class LoginViewModel: ObservableObject {
                                     switch result {
                                     case .success(let userInfo):
                                         print("🟢 자동 로그인 성공: \(userInfo.nickname)")
-                                        user.name = userInfo.nickname
-                                        user.id = userInfo.memberId
-                                        self.updateUserSession(with: user)
+                                        self.getUserCheckRate(accessToken: tokenResponse.accessToken) { checkRate in
+                                            let user = User(
+                                                id: userInfo.memberId,
+                                                name: userInfo.nickname,
+                                                friends: [],
+                                                checkRate: checkRate,
+                                                loginType: .apple,
+                                                serverAccessToken: tokenResponse.accessToken,
+                                                serverRefreshToken: tokenResponse.refreshTokenInfo.token
+                                            )
+                                            self.updateUserSession(with: user)
+                                        }
                                     case .failure(let error):
                                         print("🔴 자동 로그인 실패: \(error)")
                                     }
@@ -138,6 +141,24 @@ class LoginViewModel: ObservableObject {
                             self.errorMessage = "서버 로그인 실패: \(error.localizedDescription)"
                         }
                     }
+            }
+    }
+    
+    // 유저의 챙김률
+    func getUserCheckRate(accessToken: String, completion: @escaping (Int) -> Void) {
+            
+        BackEndAuthService.shared
+            .getUserCheckRate(accessToken: accessToken) { result in
+                switch result {
+                case .success(let success):
+                    print(
+                        "🟢 [LoginViewModel] getUserCheckRate 성공 챙김률: \(success.checkRate)"
+                    )
+                    completion(success.checkRate)
+                case .failure(let error):
+                    print("🔴 [LoginViewModel] getUserCheckRate 실패: \(error)")
+                    completion(0)
+                }
             }
     }
 }

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -30,7 +30,8 @@ public struct HomeView: View {
                             })
                             
                             // 인사 레이블
-                            GreetingSection(userName: userSession.user?.name ?? "사용자")
+                            GreetingSection(userName: userSession.user?.name ?? "사용자",
+                                            checkRate: userSession.user?.checkRate ?? 0)
                             
                             // 이번달 챙길 사람
                             ThisMonthSection(peoples: homeViewModel.thisMonthFriends)
@@ -104,17 +105,44 @@ struct CustomNavigationBar: View {
 // MARK: - 상단 레이블
 struct GreetingSection: View {
     var userName: String
-
+    var checkRate: Int
+    
+    private var message1: String {
+        switch checkRate {
+        case 1...30:
+            return "오늘은 가볍게"
+        case 31...70:
+            return "챙김 기록"
+        case 71...100:
+            return "따뜻한 챙김 덕분"
+        default:
+            return "누구를 챙길지"
+        }
+    }
+    
+    private var message2: String {
+        switch checkRate {
+        case 1...30:
+            return " 안부를 전해보면 어떨까요?"
+        case 31...70:
+            return "을 남겨두면\n더 가까워질 수 있어요."
+        case 71...100:
+            return "에 \n주변 사람들이 행복할 거에요!"
+        default:
+            return " 정해볼까요?"
+        }
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("\(userName)님,")
                 .font(Font.Pretendard.h1Medium())
                 .foregroundColor(.white)
             HStack {
-                Text("누구를 챙길지 ")
+                Text(message1)
                     .font(Font.Pretendard.h1Bold())
                     .foregroundColor(.white)
-                + Text("정해볼까요?")
+                + Text(message2)
                     .font(Font.Pretendard.h1Medium())
                     .foregroundColor(.white)
             }
@@ -323,6 +351,7 @@ struct MyPeopleSection: View {
                                     path.append(.personDetail(selected))
                                 }
                                 .tag(index)
+                                .environmentObject(HomeViewModel())
                             }
                         }
                         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
@@ -348,6 +377,7 @@ struct MyPeopleSection: View {
 
 struct StarPositionLayout: View {
     @Binding var peoples: [Friend]
+    @EnvironmentObject var homeViewModel: HomeViewModel
     let pageIndex: Int
     let onTap: (Friend) -> Void
         
@@ -428,7 +458,19 @@ struct StarPositionLayout: View {
                                             "\(contact.name): position \(contact.position ?? -1)"
                                         )
                                     }
-                                    // TODO: - 서버에 변경된 순서 전송.
+                                    // 서버에 변경된 순서 전송.
+                                    let draggingFriend = peoples[dragging]
+                                    let targetFriend = peoples[targetIndex]
+                                    homeViewModel
+                                        .patchFriendOrder(
+                                            targetID: draggingFriend.id.uuidString,
+                                            newPosition: dragging
+                                        )
+                                    homeViewModel
+                                        .patchFriendOrder(
+                                            targetID: targetFriend.id.uuidString,
+                                            newPosition: targetIndex
+                                        )
                                 }
 
                                 draggingIndex = nil
@@ -522,138 +564,3 @@ struct PersonCircleView: View {
         }
     }
 }
-
-//struct HomeView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        Group {
-//            previewForDevice("iPhone 13 mini")
-//            previewForDevice("iPhone 16")
-//            previewForDevice("iPhone 16 Pro")
-//            previewForDevice("iPhone 16 Pro Max")
-//        }
-//    }
-//    
-//    static func previewForDevice(_ deviceName: String) -> some View {
-//        let fakeFriends = [
-//            Friend(
-//                id: UUID(),
-//                name: "정종원1",
-//                image: nil,
-//                imageURL: nil,
-//                source: .kakao,
-//                frequency: CheckInFrequency.none,
-//                remindCategory: .message,
-//                nextContactAt: Calendar.current
-//                    .date(byAdding: .day, value: 0, to: Date()), // 오늘
-//                lastContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -1, to: Date()),
-//                checkRate: 20,
-//                position: 0
-//            ),
-//            Friend(
-//                id: UUID(),
-//                name: "정종원2",
-//                image: nil,
-//                imageURL: nil,
-//                source: .phone,
-//                frequency: CheckInFrequency.none,
-//                remindCategory: .anniversary,
-//                nextContactAt: Calendar.current
-//                    .date(byAdding: .day, value: 2, to: Date()), // D-2
-//                lastContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -3, to: Date()),
-//                checkRate: 45,
-//                position: 1
-//            ),
-//            Friend(
-//                id: UUID(),
-//                name: "정종원3",
-//                image: nil,
-//                imageURL: nil,
-//                source: .kakao,
-//                frequency: CheckInFrequency.none,
-//                remindCategory: .message,
-//                nextContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -1, to: Date()), // D+1
-//                lastContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -7, to: Date()),
-//                checkRate: 65,
-//                position: 2
-//            ),
-//            Friend(
-//                id: UUID(),
-//                name: "정종원4",
-//                image: nil,
-//                imageURL: nil,
-//                source: .phone,
-//                frequency: CheckInFrequency.none,
-//                remindCategory: .message,
-//                nextContactAt: Calendar.current
-//                    .date(byAdding: .day, value: 7, to: Date()), // D-7
-//                lastContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -10, to: Date()),
-//                checkRate: 85,
-//                position: 3
-//            ),
-//            Friend(
-//                id: UUID(),
-//                name: "정종원5",
-//                image: nil,
-//                imageURL: nil,
-//                source: .phone,
-//                frequency: CheckInFrequency.none,
-//                remindCategory: .birth,
-//                nextContactAt: Calendar.current
-//                    .date(byAdding: .day, value: 15, to: Date()), // D-15
-//                lastContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -14, to: Date()),
-//                checkRate: 30,
-//                position: 4
-//            ),
-//            Friend(
-//                id: UUID(),
-//                name: "정종원6",
-//                image: nil,
-//                imageURL: nil,
-//                source: .phone,
-//                frequency: CheckInFrequency.none,
-//                remindCategory: .message,
-//                nextContactAt: Calendar.current
-//                    .date(byAdding: .day, value: 7, to: Date()), // D-7
-//                lastContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -10, to: Date()),
-//                checkRate: 85,
-//                position: 3
-//            ),
-//            Friend(
-//                id: UUID(),
-//                name: "정종원7",
-//                image: nil,
-//                imageURL: nil,
-//                source: .phone,
-//                frequency: CheckInFrequency.none,
-//                remindCategory: .birth,
-//                nextContactAt: Calendar.current
-//                    .date(byAdding: .day, value: 15, to: Date()), // D-15
-//                lastContactAt: Calendar.current
-//                    .date(byAdding: .day, value: -14, to: Date()),
-//                checkRate: 30,
-//                position: 4
-//            )
-//        ]
-//        
-//        UserSession.shared.user = User(id: "", name: "프리뷰", friends: fakeFriends, loginType: .kakao, serverAccessToken: "", serverRefreshToken: "")
-//        
-//        let viewModel = HomeViewModel()
-//        viewModel.loadPeoplesFromUserSession()
-//        
-//        return HomeView(
-//            homeViewModel: viewModel,
-//            notificationViewModel: NotificationViewModel(),
-//            path: .constant([])
-//        )
-//        .environmentObject(UserSession.shared)
-//        .previewDevice(PreviewDevice(rawValue: deviceName))
-//        .previewDisplayName(deviceName)
-//    }
-//}


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 사용자 및 친구 모델에 '챙김률(checkRate)' 속성 추가 및 관련 API 연동
- 홈 화면 '내 사람들' 순서 변경 기능 구현 및 API 연동
- 로그인 시 사용자의 챙김률 정보를 함께 조회하도록 로직 수정
- 챙김률에 따라 홈 화면 인사 메시지 변경 적용

## 📄 작업 내용 상세 설명
- User 모델과 Friend 모델에 checkRate (Int 타입) 프로퍼티를 추가하여 사용자와 친구의 관계 친밀도를 나타내는 지표를 관리합니다.
- 백엔드 API와 연동하여 다음 기능을 구현했습니다:
    - 로그인 시 사용자의 checkRate 정보를 함께 받아와 UserSession에 저장합니다.
    - 친구 목록 조회 시 각 친구의 checkRate 정보를 받아옵니다.
    - 홈 화면에서 '내 사람들'의 순서를 드래그 앤 드롭으로 변경하면, 변경된 순서(position)를 서버에 업데이트하는 API를 호출합니다.
    - 친구의 checkRate를 조회하는 API를 추가했습니다. (필요시 사용)
- 홈 화면의 인사 메시지(GreetingSection)가 사용자의 checkRate에 따라 다르게 표시되도록 수정했습니다.
- HomeView의 StarPositionLayout에서 친구 순서 변경 시, 변경된 position 값을 peoples 배열에 반영하고, 해당 정보를 서버에 전송하여 동기화합니다.

### 🎯 작업 목적
- 챙김율에 따른 메세지 변경
- 친구 순서 변경 적용

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- [리뷰어가 참고해야 할 내용이나 주의할 점을 적어주세요.]

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #44 , #76 