### PR TITLE
[Feature] Firebase Analytics 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ Tuist/Package.resolved
 
 # Tuist Config
 Tuist/Config/Config.xcconfig
+
+# Firebase
+Tuist/GoogleService-Info.plist

--- a/Project.swift
+++ b/Project.swift
@@ -45,6 +45,7 @@ let project = Project(
                         "Pretendard-SemiBold.otf",
                         "Pretendard-Thin.otf",
                     ],
+                    "FirebaseAutomaticScreenReportingEnabled": false,
 //                    "LSApplicationQueriesSchemes": [
 //                        "kakaokompassauth" // 앱으로 로그인
 //                    ],

--- a/Project.swift
+++ b/Project.swift
@@ -63,7 +63,8 @@ let project = Project(
             sources: [
                 "SwypApp2nd/Sources/**"
             ],
-            resources: ["SwypApp2nd/Resources/**"
+            resources: ["SwypApp2nd/Resources/**",
+                        "Tuist/GoogleService-Info.plist"
 //                       "SwypApp2nd/Resources/External/KakaoSDKFriendResources.bundle"
                        ],
             entitlements: "Tuist/SignInWithApple.entitlements",
@@ -75,12 +76,15 @@ let project = Project(
                 .external(name: "KakaoSDKAuth"),
                 .external(name: "KakaoSDKUser"),
                 .external(name: "KakaoSDKTalk"),
-                .external(name: "KakaoSDKFriend")
+                .external(name: "KakaoSDKFriend"),
+                .external(name: "FirebaseAnalytics")
+                
             ],
             settings: .settings(base: [
                 "RUN_EXECUTABLE_PATH": "$(BUILT_PRODUCTS_DIR)/SwypApp2nd.app",
                 "MARKETING_VERSION": "1.0.0",
-                "CURRENT_PROJECT_VERSION": "11"
+                "CURRENT_PROJECT_VERSION": "11",
+                "OTHER_LDFLAGS": "$(inherited) -ObjC"
             ]),
             coreDataModels: [
                 .coreDataModel(

--- a/SwypApp2nd/Sources/ContentView.swift
+++ b/SwypApp2nd/Sources/ContentView.swift
@@ -54,13 +54,16 @@ public struct ContentView: View {
                     contactFrequencyViewModel.setPeople(from: registerFriendsViewModel.selectedContacts) // 선택된 연락처 전달
                     print("🟢 [RegisterFriendsViewModel] \(registerFriendsViewModel.selectedContacts) 전달됨")
                     userSession.appStep = .setFrequency
+                    AnalyticsManager.shared.nextButtonLogAnalytics()
                 }, skip: {
                     userSession.appStep = .home
+                    AnalyticsManager.shared.skipButtonLogAnalytics()
                 })
                 
             case .setFrequency:
                 ContactFrequencySettingsView(viewModel: contactFrequencyViewModel, notificationViewModel: notificationViewModel, back: {
                     userSession.appStep = .registerFriends
+                    AnalyticsManager.shared.previousButtonLogAnalytics()
                 }, complete: { updatedPeoples in
                     DispatchQueue.main.async {
                         print("🟢 [ContactFrequencySettingsView] 전달받은 people: \(updatedPeoples.map { $0.name })")

--- a/SwypApp2nd/Sources/GlobalState/NotificationManager.swift
+++ b/SwypApp2nd/Sources/GlobalState/NotificationManager.swift
@@ -55,6 +55,7 @@ class NotificationManager: NSObject, ObservableObject, UNUserNotificationCenterD
         let userInfo = response.notification.request.content.userInfo
         // auto login check -> app step 쌓는 과정
         notificationViewModel.navigateFromNotification(userInfo: userInfo)  // CoreData 저장
+        AnalyticsManager.shared.setEntryChannel("push")
         completionHandler()
     }
     

--- a/SwypApp2nd/Sources/Services/AnalyticsManager.swift
+++ b/SwypApp2nd/Sources/Services/AnalyticsManager.swift
@@ -190,6 +190,12 @@ final class AnalyticsManager {
         print("📊 [Analytics] click_notification_list_item: \(careType) 로 전송")
     }
     
+    func trackNotificationInboxLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "NotificationInboxView",
+                                       AnalyticsParameterScreenClass: "NotificationInboxView"])
+    }
+    
     // MARK: - PushNotification
     /// 푸시 알림 클릭 시 ( push_type: "manual_reminder", "birthday_reminder", "anniversary_reminder" )
     func pushListItemTapped(pushType: String) {

--- a/SwypApp2nd/Sources/Services/AnalyticsManager.swift
+++ b/SwypApp2nd/Sources/Services/AnalyticsManager.swift
@@ -1,0 +1,240 @@
+import Foundation
+import FirebaseAnalytics
+
+final class AnalyticsManager {
+    static let shared = AnalyticsManager()
+    
+    private init() { }
+    
+    // MARK: - HomeView
+    func myProfileLogAnalytics() {
+        Analytics.logEvent("click_my_profile_btn", parameters: nil)
+        print("📊 [Analytics] click_my_profile_btn 전송")
+    }
+    
+    func notificationLogAnalytics() {
+        Analytics.logEvent("click_notification_btn", parameters: nil)
+        print("📊 [Analytics] click_notification_btn 전송")
+    }
+    
+    func addPersonLogAnalytics() {
+        Analytics.logEvent("click_add_person_btn", parameters: nil)
+        print("📊 [Analytics] click_add_person_btn 전송")
+    }
+    
+    func selectPersonLogAnalytics() {
+        Analytics.logEvent("click_select_person_btn", parameters: nil)
+        print("📊 [Analytics] click_select_person_btn 전송")
+    }
+    
+    func trackHomeViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "HomeView",
+                                       AnalyticsParameterScreenClass: "HomeView"])
+    }
+    
+    // MARK: - LoginView
+    func kakaoLoginLogAnalytics() {
+        Analytics.logEvent("click_signup_btn", parameters: [
+            "method": "kakao"
+        ])
+        print("📊 [Analytics] click_signup_btn: kakao 로 전송")
+    }
+    
+    func appleLoginLogAnalytics() {
+        Analytics.logEvent("click_signup_btn", parameters: [
+            "method": "apple"
+        ])
+        print("📊 [Analytics] click_signup_btn: apple 로 전송")
+    }
+    
+    func trackLoginViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "LoginView",
+                                       AnalyticsParameterScreenClass: "LoginView"])
+    }
+    
+    // MARK: - TermsView
+    func agreementLogAnalytics() {
+        Analytics.logEvent("click_agreement_btn", parameters: nil)
+        print("📊 [Analytics] click_agreement_btn 전송")
+    }
+    
+    func trackTermsViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "TermsView",
+                                       AnalyticsParameterScreenClass: "TermsView"])
+    }
+    
+    // MARK: - RegisterFriendsView
+    func contactImportLogAnalytics() {
+        Analytics.logEvent("click_contact_import_btn", parameters: nil)
+        print("📊 [Analytics] click_contact_import_btn 전송")
+    }
+    
+    func skipButtonLogAnalytics() {
+        Analytics.logEvent("click_skip_btn", parameters: nil)
+        print("📊 [Analytics] click_skip_btn 전송")
+    }
+    
+    func nextButtonLogAnalytics() {
+        Analytics.logEvent("click_next_btn", parameters: nil)
+        print("📊 [Analytics] click_next_btn 전송")
+    }
+    
+    func trackRegisterFriendsViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "RegisterFriendsView",
+                                       AnalyticsParameterScreenClass: "RegisterFriendsView"])
+    }
+    
+    // MARK: - ContactFrequencySettingsView
+    func setCareFrequencyLogAnalytics() {
+        Analytics.logEvent("click_set_care_frequency_btn", parameters: nil)
+        print("📊 [Analytics] click_set_care_frequency_btn 전송")
+    }
+    
+    func previousButtonLogAnalytics() {
+        Analytics.logEvent("click_previous_btn", parameters: nil)
+        print("📊 [Analytics] click_set_care_frequency_btn 전송")
+    }
+    
+    func completeButtonLogAnalytics() {
+        Analytics.logEvent("click_complete_profile_btn", parameters: nil)
+        print("📊 [Analytics] click_complete_profile_btn 전송")
+    }
+    
+    func trackContactFrequencySettingsViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "FrequencyView",
+                                       AnalyticsParameterScreenClass: "FrequencyView"])
+    }
+    
+    // MARK: - ProfileDetailView
+    func callButtonLogAnalytics() {
+        Analytics.logEvent("click_call_person_btn", parameters: nil)
+        print("📊 [Analytics] click_call_person_btn 전송")
+    }
+    
+    func messageButtonLogAnalytics() {
+        Analytics.logEvent("click_message_person_btn", parameters: nil)
+        print("📊 [Analytics] click_message_person_btn 전송")
+    }
+    
+    func profileTabLogAnalytics() {
+        Analytics.logEvent("click_tab_profile_btn", parameters: nil)
+        print("📊 [Analytics] click_tab_profile_btn 전송")
+    }
+    
+    func historyTapLogAnalytics() {
+        Analytics.logEvent("click_tab_history_btn", parameters: nil)
+        print("📊 [Analytics] click_tab_history_btn 전송")
+    }
+    
+    func dailyCheckButtonLogAnalytics() {
+        Analytics.logEvent("click_daily_check_btn", parameters: nil)
+        print("📊 [Analytics] click_daily_check_btn 전송")
+    }
+    
+    func trackProfileDetailViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "ProfileDetailView",
+                                       AnalyticsParameterScreenClass: "ProfileDetailView"])
+    }
+    
+    // MARK: - ProfileEditView
+    func trackProfileEditViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "ProfileEditView",
+                                       AnalyticsParameterScreenClass: "ProfileEditView"])
+    }
+    
+    // MARK: - MyProfileView
+    func notificationSettingButtonLogAnalytics(isOn: Bool) {
+        Analytics.logEvent("click_notification_setting_btn", parameters: [
+            "toggle_state": isOn ? "on" : "off"
+        ])
+        setNotificationOn(isOn)
+        print("📊 [Analytics] click_notification_setting_btn: \(isOn) 로 전송")
+    }
+    
+    func logoutButtonLogAnalytics() {
+        Analytics.logEvent("click_logout_btn", parameters: nil)
+        print("📊 [Analytics] click_logout_btn 전송")
+    }
+    
+    func withdrawButtonLogAnalytics() {
+        Analytics.logEvent("click_withdraw_btn", parameters: nil)
+        print("📊 [Analytics] click_withdraw_btn 전송")
+    }
+    
+    func trackMyProfileViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "MyProfileView",
+                                       AnalyticsParameterScreenClass: "MyProfileView"])
+    }
+    
+    // MARK: - WithDrawalView
+    func trackWithDrawalViewLogAnalytics() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [AnalyticsParameterScreenName: "WithDrawalView",
+                                       AnalyticsParameterScreenClass: "WithDrawalView"])
+    }
+        
+    // MARK: - NotificationInbox
+    /// 알림 리스트 클릭 시 ( care_type: "manual", "birthday", "anniversary" )
+    func notificationListItemTapped(careType: String) {
+        Analytics.logEvent("click_notification_list_item", parameters: [
+            "care_type": careType
+        ])
+        print("📊 [Analytics] click_notification_list_item: \(careType) 로 전송")
+    }
+    
+    // MARK: - PushNotification
+    /// 푸시 알림 클릭 시 ( push_type: "manual_reminder", "birthday_reminder", "anniversary_reminder" )
+    func pushListItemTapped(pushType: String) {
+        Analytics.logEvent("click_push_list_item", parameters: [
+            "push_type": pushType
+        ])
+        print("📊 [Analytics] click_push_list_item: \(pushType) 로 전송")
+    }
+    
+    // MARK: - 사용자 속성
+    func setProfileCountBucket(_ count: Int) {
+        let bucket: String
+        switch count {
+        case 0: bucket = "0"
+        case 1...3: bucket = "1-3"
+        case 4...6: bucket = "4-6"
+        default: bucket = "7+"
+        }
+        Analytics.setUserProperty(bucket, forName: "profile_count_bucket")
+        print("📊 [Analytics] profile_count_bucket: \(bucket) 로 전송")
+        
+    }
+    
+    // TODO: - 온보딩 추가후 적용
+    func setOnboardingDone() {
+        Analytics.setUserProperty("y", forName: "onboarding_done")
+        print("📊 [Analytics] onboarding_done: y 로 전송")
+        
+    }
+    
+    // TODO: - 첫 챙길 사람 등록 여부 어떻게..? 서버와 회의 필요
+    func setFirstAddPersonDone() {
+        Analytics.setUserProperty("y", forName: "first_add_person_done")
+        print("📊 [Analytics] first_add_person_done: y 로 전송")
+    }
+    
+    // TODO: - 푸시 또는 실행 어떻게..?
+    /// 앱 실행 경로 ( channel: "direct", "push" )
+    func setEntryChannel(_ channel: String) {
+        Analytics.setUserProperty(channel, forName: "entry_channel")
+        print("📊 [Analytics] entry_channel: \(channel) 로 전송")
+    }
+    
+    func setNotificationOn(_ isOn: Bool) {
+        Analytics.setUserProperty(isOn ? "y" : "n", forName: "notification_on")
+        print("📊 [Analytics] notification_on: \(isOn) 로 전송")
+    }
+}

--- a/SwypApp2nd/Sources/SwypApp2ndApp.swift
+++ b/SwypApp2nd/Sources/SwypApp2ndApp.swift
@@ -1,11 +1,13 @@
 import SwiftUI
+import Firebase
 
 @main
 struct SwypApp2ndApp: App {
     
     init() {
-            NotificationManager.shared.requestPermissionIfNeeded()
-        }
+        NotificationManager.shared.requestPermissionIfNeeded()
+        FirebaseApp.configure()
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/SwypApp2nd/Sources/SwypApp2ndApp.swift
+++ b/SwypApp2nd/Sources/SwypApp2ndApp.swift
@@ -7,6 +7,7 @@ struct SwypApp2ndApp: App {
     init() {
         NotificationManager.shared.requestPermissionIfNeeded()
         FirebaseApp.configure()
+        AnalyticsManager.shared.setEntryChannel("direct")
     }
 
     var body: some Scene {

--- a/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
@@ -2,6 +2,7 @@ import AuthenticationServices
 import Foundation
 import Combine
 import KakaoSDKUser
+import FirebaseAnalytics
 
 class LoginViewModel: ObservableObject {
 
@@ -18,6 +19,10 @@ class LoginViewModel: ObservableObject {
        
     // MARK: - 카카오 로그인 흐름
     func loginWithKakao() {
+        Analytics.logEvent("LoginView", parameters: [
+            "button": "kakao_login"
+        ])
+        
         isLoading = true
         SnsAuthService.shared.loginWithKakao { oauthToken in
             guard let token = oauthToken else {
@@ -76,6 +81,9 @@ class LoginViewModel: ObservableObject {
 
     // MARK: - 애플 로그인 요청 세팅
     func handleAppleRequest(_ request: ASAuthorizationAppleIDRequest) {
+        Analytics.logEvent("LoginView", parameters: [
+            "button": "apple_login"
+        ])
         SnsAuthService.shared.configureAppleRequest(request)
     }
 

--- a/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
@@ -19,9 +19,7 @@ class LoginViewModel: ObservableObject {
        
     // MARK: - 카카오 로그인 흐름
     func loginWithKakao() {
-        Analytics.logEvent("LoginView", parameters: [
-            "button": "kakao_login"
-        ])
+        AnalyticsManager.shared.kakaoLoginLogAnalytics()
         
         isLoading = true
         SnsAuthService.shared.loginWithKakao { oauthToken in
@@ -81,9 +79,7 @@ class LoginViewModel: ObservableObject {
 
     // MARK: - 애플 로그인 요청 세팅
     func handleAppleRequest(_ request: ASAuthorizationAppleIDRequest) {
-        Analytics.logEvent("LoginView", parameters: [
-            "button": "apple_login"
-        ])
+        AnalyticsManager.shared.appleLoginLogAnalytics()
         SnsAuthService.shared.configureAppleRequest(request)
     }
 

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -23,11 +23,15 @@ public struct HomeView: View {
                     VStack {
                         VStack(spacing: 24) {
                             // 네비게이션 바
-                            CustomNavigationBar(showBadge: notificationViewModel.showBadge,
-                                                onTapMy: {DispatchQueue.main.async {
-                                path.append(.my)} },
-                                                onTapBell: { DispatchQueue.main.async { path.append(.inbox) }
-                            })
+                            CustomNavigationBar(
+                                showBadge: notificationViewModel.showBadge,
+                                onTapMy: { DispatchQueue.main.async { path.append(.my) }
+                                    AnalyticsManager.shared.myProfileLogAnalytics()
+                                },
+                                onTapBell: { DispatchQueue.main.async { path.append(.inbox) }
+                                    AnalyticsManager.shared.notificationLogAnalytics()
+                                }
+                            )
                             
                             // 인사 레이블
                             GreetingSection(userName: userSession.user?.name ?? "사용자")
@@ -51,6 +55,9 @@ public struct HomeView: View {
         .onAppear {
             homeViewModel.loadFriendList()
             homeViewModel.loadMonthlyFriends()
+                
+            AnalyticsManager.shared.trackHomeViewLogAnalytics()
+                
         }
         .onReceive(notificationViewModel.$navigateToPerson.compactMap { $0 }) { friend in
             path.removeAll()
@@ -300,6 +307,7 @@ struct MyPeopleSection: View {
                     VStack(alignment: .center, spacing: 8) {
                         Button {
                             UserSession.shared.appStep = .registerFriends
+                            AnalyticsManager.shared.addPersonLogAnalytics()
                         } label: {
                             Image(systemName: "plus")
                                 .font(.title)
@@ -321,6 +329,7 @@ struct MyPeopleSection: View {
                             ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
                                 StarPositionLayout(peoples: $peoples , pageIndex: index) { selected in
                                     path.append(.personDetail(selected))
+                                    AnalyticsManager.shared.selectPersonLogAnalytics()
                                 }
                                 .tag(index)
                             }

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
@@ -46,6 +46,7 @@ struct ProfileDetailView: View {
                 isEnabled: viewModel.canCheckInToday
             ) {
                 viewModel.checkFriend()
+                AnalyticsManager.shared.dailyCheckButtonLogAnalytics()
             }
         }
         .padding(.horizontal, 24)
@@ -53,6 +54,8 @@ struct ProfileDetailView: View {
         .onAppear {
             viewModel.fetchFriendDetail(friendId: viewModel.people.id)
             viewModel.fetchFriendRecords(friendId: viewModel.people.id)
+            
+            AnalyticsManager.shared.trackProfileDetailViewLogAnalytics()
         }
         .toolbar {
             ToolbarItem(placement: .topBarLeading)  {
@@ -363,10 +366,16 @@ private struct ProfileTabBar: View {
     var body: some View {
         HStack {
             TabButton(title: "프로필", isSelected: selected == .profile)
-                .onTapGesture { selected = .profile }
+                .onTapGesture {
+                    selected = .profile
+                    AnalyticsManager.shared.profileTabLogAnalytics()
+                }
 
             TabButton(title: "기록", isSelected: selected == .records)
-                .onTapGesture { selected = .records }
+                .onTapGesture {
+                    selected = .records
+                    AnalyticsManager.shared.historyTapLogAnalytics()
+                }
 
         }
     }

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileEditView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileEditView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import CoreData
 
 struct ProfileEditView: View {
     @ObservedObject var profileEditViewModel: ProfileEditViewModel
@@ -25,6 +24,9 @@ struct ProfileEditView: View {
                 )
                 MemoSection(memo: $profileEditViewModel.person.memo)
             }
+        }
+        .onAppear {
+            AnalyticsManager.shared.trackProfileEditViewLogAnalytics()
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -96,6 +96,7 @@ struct ContactFrequencySettingsView: View {
                         ) {
                             selectedPerson = person
                             showFrequencyPicker = true
+                            AnalyticsManager.shared.setCareFrequencyLogAnalytics()
                         }
                     }
                 }
@@ -121,15 +122,17 @@ struct ContactFrequencySettingsView: View {
                 }
 
                 Button{
-                    // 카카오는 이미지 저장 후 BackEnd 서버에 전송
-                    viewModel.downloadKakaoImageData { friendsWithImages in
-                        DispatchQueue.main.async {
-                            viewModel.uploadAllFriendsToServer(viewModel.people) {
-                                UserSession.shared.user?.friends = viewModel.people
-                                complete(viewModel.people)
-                            }
+                    // 카카오는 이미지 저장 후 BackEnd 서버에 전송 (스펙 아웃)
+//                    viewModel.downloadKakaoImageData { friendsWithImages in
+//                    }
+                    
+                    DispatchQueue.main.async {
+                        viewModel.uploadAllFriendsToServer(viewModel.people) {
+                            UserSession.shared.user?.friends = viewModel.people
+                            AnalyticsManager.shared.setProfileCountBucket(viewModel.people.count)
+                            AnalyticsManager.shared.completeButtonLogAnalytics()
+                            complete(viewModel.people)
                         }
-                        
                     }
                 }
                 label: {
@@ -162,6 +165,9 @@ struct ContactFrequencySettingsView: View {
             )
             .presentationDetents([.medium])
             .presentationDragIndicator(.visible)
+        }
+        .onAppear {
+            AnalyticsManager.shared.trackContactFrequencySettingsViewLogAnalytics()
         }
     }
 }
@@ -312,23 +318,3 @@ struct FrequencyPickerView: View {
         .cornerRadius(20)
     }
 }
-
-//#Preview {
-//    let viewModel: ContactFrequencySettingsViewModel = {
-//        let vm = ContactFrequencySettingsViewModel()
-//        vm.people = [
-//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.kakao, frequency: CheckInFrequency.none),
-//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
-//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none),
-//            Friend(id: UUID(), name: "정종원", image: nil, source: ContactSource.phone, frequency: CheckInFrequency.none)
-//        ]
-//        return vm
-//    }()
-//    ContactFrequencySettingsView(
-//        viewModel: viewModel,
-//        back: { print("이전") },
-//        complete: { print("완료") }
-//    )
-//}

--- a/SwypApp2nd/Sources/Views/Login/LoginView.swift
+++ b/SwypApp2nd/Sources/Views/Login/LoginView.swift
@@ -62,6 +62,9 @@ public struct LoginView: View {
             .padding(.horizontal, 24)
             .padding(.bottom, 40)
         }
+        .onAppear {
+            AnalyticsManager.shared.trackLoginViewLogAnalytics()
+        }
     }
 }
 #Preview {

--- a/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
@@ -81,6 +81,7 @@ struct RegisterFriendView: View {
                                         showPermissionAlert = true
                                     }
                                 }
+                                AnalyticsManager.shared.contactImportLogAnalytics()
                             }
                         )
                         .sheet(isPresented: $showContactPicker) {
@@ -173,6 +174,9 @@ struct RegisterFriendView: View {
                 },
                 secondaryButton: .cancel(Text("취소"))
             )
+        }
+        .onAppear {
+            AnalyticsManager.shared.trackRegisterFriendsViewLogAnalytics()
         }
     }
 }

--- a/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
@@ -107,6 +107,8 @@ public struct TermsView: View {
                     print("🟢 [TermsView] didAgreeToAppleTerms 저장됨: \(UserDefaults.standard.bool(forKey: "didAgreeToAppleTerms"))")
                 }
                 
+                AnalyticsManager.shared.agreementLogAnalytics()
+                
                 completion()
             }) {
                 Text("가입")
@@ -145,6 +147,9 @@ public struct TermsView: View {
                     }
                 }
             }
+        }
+        .onAppear {
+            AnalyticsManager.shared.trackTermsViewLogAnalytics()
         }
     }
 }

--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -59,6 +59,9 @@ struct MyProfileView: View {
             }
         }
         .padding(.horizontal, 12)
+        .onAppear {
+            AnalyticsManager.shared.trackMyProfileViewLogAnalytics()
+        }
     }
 }
 
@@ -133,10 +136,11 @@ struct NotificationSettingsView: View {
             }
             .onChange(of: viewModel.isNotificationOn) {newValue in
                 if newValue {
-                        viewModel.handleToggleOn()
+                    viewModel.handleToggleOn()
                 } else {
                     viewModel.turnOffNotifications()
                 }
+                AnalyticsManager.shared.notificationSettingButtonLogAnalytics(isOn: newValue)
             }
             .alert("휴대폰 알림이 꺼져 있어요.", isPresented: $viewModel.showSettingsAlert) {
             Button("설정하러 가기") {
@@ -248,6 +252,7 @@ struct WithdrawalButtonView: View {
                         }
                     }
                 }
+                AnalyticsManager.shared.logoutButtonLogAnalytics()
             }) {
                 Text("로그아웃")
                     .font(Font.Pretendard.b1Bold())
@@ -264,6 +269,7 @@ struct WithdrawalButtonView: View {
             
             Button(action: {
                 onWithdrawTap()
+                AnalyticsManager.shared.withdrawButtonLogAnalytics()
             }) {
                 Text("탈퇴하기")
                     .font(Font.Pretendard.b2Medium())

--- a/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
+++ b/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
@@ -38,6 +38,9 @@ struct WithdrawalView: View {
             )
         }
         .padding(.horizontal, 24)
+        .onAppear {
+            AnalyticsManager.shared.trackWithDrawalViewLogAnalytics()
+        }
 }
 
 struct WithdrawalHeaderView: View {

--- a/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
+++ b/SwypApp2nd/Sources/Views/Notification/NotificationInboxView.swift
@@ -11,6 +11,8 @@ struct NotificationInboxView: View {
         .navigationTitle("알림")
         .onAppear {
             notificationViewModel.loadAllReminders()
+            
+            AnalyticsManager.shared.trackNotificationInboxLogAnalytics()
         }
     }
 

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -8,6 +8,7 @@ let packageSettings = PackageSettings(
     productTypes: ["Alamofire": .framework,
                    "Kingfisher": .framework,
                    "KakaoOpenSDK": .framework,
+                   "Firebase": .framework,
                   ]
 )
 #endif
@@ -20,6 +21,7 @@ let package = Package(
             url: "https://github.com/onevcat/Kingfisher.git",
             from: "7.0.0"
         ),
-        .package(url: "https://github.com/kakao/kakao-ios-sdk", exact: "2.24.0")
+        .package(url: "https://github.com/kakao/kakao-ios-sdk", exact: "2.24.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.12.0"),
     ]
 )


### PR DESCRIPTION
## ✨ 변경 사항 요약
- Firebase Analytics 화면 조회 및 사용자 이벤트/속성 추적 기능을 AnalyticsManager로 통합 적용하였습니다.

## 📄 작업 내용 상세 설명
- AnalyticsManager 내 공통 이벤트 추적 메서드(logEvent, logUserProperty) 추가
- 버튼 클릭, 화면 조회, 사용자 속성 관련 추적 로직을 AnalyticsManager에 통합
- 화면별 .onAppear에서 trackSomethingView() 호출 적용
- 푸시 클릭 시 진입 경로(entry_channel)를 "push"로 설정
- 앱 실행 시 기본 진입 경로를 "direct"로 설정
- Debug 콘솔에 로그 출력 추가

### 🎯 작업 목적
- Firebase Analytics 설정 및 로그 수집을 구조화하고 일관된 방식으로 관리

### 🛠️ 주요 변경 사항
- AnalyticsManager.swift : 이벤트 및 사용자 속성 통합 추적 기능 구현

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 사용자 속성을 GA에서 활용하려면 FirebaseConsole -> Custom Deficitions 에서 수동 등록이 필요합니다!
- 현재 첫 챙길사람 등록 관련 Analytics 메소드가 연결되어있지 않습니다.
- 현재 온보딩 Analytics 메소드가 연결되어있지 않습니다.
- PushNoti 관련 Analytics 메소드가 연결되어있지 않습니다!

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #96 