### PR TITLE
fix: 약관 동의 상태 초기화 로직 추가

### DIFF
--- a/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
@@ -108,6 +108,9 @@ public struct TermsView: View {
                 }
                 
                 AnalyticsManager.shared.agreementLogAnalytics()
+                viewModel.isServiceTermsAgreed = false
+                viewModel.isPersonalInfoTermsAgreed = false
+                viewModel.isPrivacyPolicyAgreed = false
                 
                 completion()
             }) {


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 약관 동의 상태 초기화 로직을 추가했습니다.

## 📄 작업 내용 상세 설명
- 회원가입 또는 약관 동의 화면 진입 시, 이전에 체크된 약관 동의 상태가 남아있는 문제를 해결하기 위해 약관 동의 상태를 초기화하는 로직을 추가했습니다.
- 사용자가 약관 동의 화면에 진입할 때마다 모든 동의 체크박스가 해제된 상태로 시작됩니다.
- 관련 함수 및 변수 초기화 코드가 추가되었습니다.

### 🎯 작업 목적
- 약관 동의 화면 진입 시, 이전 동의 상태가 남아있어 발생하는 사용자 혼란을 방지하기 위함입니다.

### 🛠️ 주요 변경 사항
- 약관 동의 상태를 관리하는 변수 초기화 코드 추가

### 📸 스크린샷 (필요시 추가)

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [x] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. 

### ⚠️ 주의사항 및 참고사항
- 기존에 저장된 동의 상태가 있다면 초기화됨을 유의해주세요.
- 추가적인 상태 관리가 필요한 경우 리뷰 부탁드립니다.

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #89 