### PR TITLE
[Feature] 사람 명수에 따른 레이아웃 및 추가 버튼 위치 조정

### DIFF
--- a/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
@@ -108,6 +108,9 @@ public struct TermsView: View {
                 }
                 
                 AnalyticsManager.shared.agreementLogAnalytics()
+                viewModel.isServiceTermsAgreed = false
+                viewModel.isPersonalInfoTermsAgreed = false
+                viewModel.isPrivacyPolicyAgreed = false
                 
                 completion()
             }) {


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 사람(내사람들) 명수에 따라 레이아웃 및 추가 버튼 위치를 조정했습니다.

## 📄 작업 내용 상세 설명
- 내사람들 명수(1~5명)에 따라 각기 다른 레이아웃이 적용되도록 UI를 수정했습니다.
- 추가 버튼의 위치가 사람 명수에 따라 자연스럽게 배치되도록 동적으로 조정했습니다.
- 레이아웃 변경에 따른 UI 요소의 정렬 및 마진 값을 조정했습니다.
- 각 명수별로 정상적으로 동작하는지 확인했습니다.

### 🎯 작업 목적
- 다양한 사람 명수 상황에서 UI가 깨지지 않고, 사용자 경험을 개선하기 위함입니다.

### 🛠️ 주요 변경 사항
- 사람 명수에 따른 레이아웃 동적 적용 로직 추가
- 추가 버튼 위치 동적 조정
- 관련 UI 요소 마진/정렬 값 수정

### 📸 스크린샷 (명수별 레이아웃)
| 명수 | 스크린샷 |
|:---:|:---:|
| 0명 | ![내 사람들 0명](https://github.com/user-attachments/assets/16de1aaf-7d45-4352-854f-456e44056a90) |
| 1명 | ![내 사람들 1명](https://github.com/user-attachments/assets/e9fe50d6-c92a-4187-808e-b71cb2b06dc5) |
| 2명 | ![내 사람들 2명](https://github.com/user-attachments/assets/dfe21376-5159-4dbe-a81e-16563544eb6f) |
| 3명 | ![내 사람들 3명](https://github.com/user-attachments/assets/4c296d99-430f-4a68-a7a5-71dcb9ac886a) |
| 4명 | ![내 사람들 4명](https://github.com/user-attachments/assets/c74457b8-3747-4b0b-a52a-ca5e7aee3baa) |
| 5명 | ![내 사람들 5명](https://github.com/user-attachments/assets/1fd4ea81-4ff5-408e-8c6d-f1d454540ca7) |

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 다양한 해상도 및 기기에서 레이아웃이 정상적으로 동작하는지 추가 확인이 필요합니다.
- 추가 버튼 위치가 예상과 다르게 보일 경우 피드백 부탁드립니다.

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #19 