### PR TITLE
[Refactor] Pretendard 폰트 스타일에 LineHeight, LetterSpacing 적용 및 .modifier 스타일 전환

### DIFF
--- a/SwypApp2nd/Sources/Common/Font+Extension.swift
+++ b/SwypApp2nd/Sources/Common/Font+Extension.swift
@@ -1,5 +1,4 @@
 import Foundation
-
 import SwiftUI
 
 extension Font {
@@ -7,49 +6,86 @@ extension Font {
         static func h1Bold(size: CGFloat = 24) -> Font {
             Font.custom("Pretendard-Bold", size: size)
         }
-        
         static func h1Medium(size: CGFloat = 24) -> Font {
             Font.custom("Pretendard-Medium", size: size)
         }
-        
         static func h1Regular(size: CGFloat = 24) -> Font {
             Font.custom("Pretendard-Regular", size: size)
         }
-        
         static func h2Bold(size: CGFloat = 18) -> Font {
             Font.custom("Pretendard-Bold", size: size)
         }
-        
         static func b1Bold(size: CGFloat = 16) -> Font {
             Font.custom("Pretendard-Bold", size: size)
         }
-        
         static func b1Medium(size: CGFloat = 16) -> Font {
             Font.custom("Pretendard-Medium", size: size)
         }
-        
         static func b2Bold(size: CGFloat = 14) -> Font {
             Font.custom("Pretendard-Bold", size: size)
         }
-        
         static func b2Medium(size: CGFloat = 14) -> Font {
             Font.custom("Pretendard-Medium", size: size)
         }
-        
         static func captionBold(size: CGFloat = 12) -> Font {
             Font.custom("Pretendard-Bold", size: size)
         }
-        
         static func captionMedium(size: CGFloat = 12) -> Font {
             Font.custom("Pretendard-Medium", size: size)
         }
+
+        // ViewModifier 반환
+        static func h1BoldStyle() -> PretendardTextStyle { .init(font: h1Bold(), lineHeight: 34, letterSpacing: -0.25) }
+        static func h1MediumStyle() -> PretendardTextStyle { .init(font: h1Medium(), lineHeight: 34, letterSpacing: -0.25) }
+        static func h1RegularStyle() -> PretendardTextStyle { .init(font: h1Regular(), lineHeight: 34, letterSpacing: -0.25) }
+        static func h2BoldStyle() -> PretendardTextStyle { .init(font: h2Bold(), lineHeight: 24, letterSpacing: -0.25) }
+        static func b1BoldStyle() -> PretendardTextStyle { .init(font: b1Bold(), lineHeight: 22, letterSpacing: -0.25) }
+        static func b1MediumStyle() -> PretendardTextStyle { .init(font: b1Medium(), lineHeight: 22, letterSpacing: -0.25) }
+        static func b2BoldStyle() -> PretendardTextStyle { .init(font: b2Bold(), lineHeight: 20, letterSpacing: -0.25) }
+        static func b2MediumStyle() -> PretendardTextStyle { .init(font: b2Medium(), lineHeight: 20, letterSpacing: -0.25) }
+        static func captionBoldStyle() -> PretendardTextStyle { .init(font: captionBold(), lineHeight: 18, letterSpacing: -0.25) }
+        static func captionMediumStyle() -> PretendardTextStyle { .init(font: captionMedium(), lineHeight: 18, letterSpacing: -0.25) }
     }
+}
+
+// PretendardTextStyle ViewModifier
+struct PretendardTextStyle: ViewModifier {
+    let font: Font
+    let lineHeight: CGFloat
+    let letterSpacing: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .font(font)
+            .lineSpacing(lineHeight - fontSize(from: font))
+            .tracking(letterSpacing)
+    }
+
+    // Pretendard 폰트 크기 추출 (Font.custom 사용 시)
+    private func fontSize(from font: Font) -> CGFloat {
+        // Pretendard-XX, size: YY
+        let mirror = Mirror(reflecting: font)
+        for child in mirror.children {
+            if let provider = child.value as? CTFontProvider,
+               let size = provider.fontSize {
+                return size
+            }
+        }
+        // 기본값
+        return 16
+    }
+}
+
+// CTFontProvider 프로토콜
+private protocol CTFontProvider {
+    var fontSize: CGFloat? { get }
+}
+extension CTFontProvider {
+    var fontSize: CGFloat? { nil }
 }
 
 // MARK: - Example
 /*
 Text("Example")
-   .font(Font.Pretendard.h1Bold())
-   .tracking(-0.25)
-   .lineSpacing(10)
+   .modifier(Font.Pretendard.h1BoldStyle())
 */

--- a/SwypApp2nd/Sources/Views/Home/HomeView.swift
+++ b/SwypApp2nd/Sources/Views/Home/HomeView.swift
@@ -82,7 +82,7 @@ struct CustomNavigationBar: View {
                     onTapMy()
                 } label: {
                     Text("MY")
-                        .font(Font.Pretendard.h2Bold())
+                        .modifier(Font.Pretendard.h2BoldStyle())
                         .foregroundStyle(Color.white)
                 }
                 Button {
@@ -143,14 +143,14 @@ struct GreetingSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("\(userName)님,")
-                .font(Font.Pretendard.h1Medium())
+                .modifier(Font.Pretendard.h1MediumStyle())
                 .foregroundColor(.white)
-            HStack {
+            HStack(spacing: 0) {
                 Text(message1)
-                    .font(Font.Pretendard.h1Bold())
+                    .modifier(Font.Pretendard.h1BoldStyle())
                     .foregroundColor(.white)
-                + Text(message2)
-                    .font(Font.Pretendard.h1Medium())
+                Text(message2)
+                    .modifier(Font.Pretendard.h1MediumStyle())
                     .foregroundColor(.white)
             }
         }
@@ -167,7 +167,7 @@ struct ThisMonthSection: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("이번달 챙길 사람")
-                    .font(Font.Pretendard.b1Bold())
+                    .modifier(Font.Pretendard.b1BoldStyle())
                     .foregroundColor(.white)
                 Spacer()
                 // TODO: - 2차때..
@@ -192,7 +192,7 @@ struct ThisMonthSection: View {
                     .frame(height: 48)
                     .overlay(
                         Text("이번달은 챙길 사람이 없네요.")
-                            .font(Font.Pretendard.b2Medium())
+                            .modifier(Font.Pretendard.b2MediumStyle())
                             .foregroundColor(.white.opacity(0.8))
                     )
                     .padding(.horizontal, 24)
@@ -235,17 +235,17 @@ struct ThisMonthContactCell: View {
                 }
 
                 Text(contact.name)
-                    .font(.Pretendard.b1Bold())
+                    .modifier(Font.Pretendard.b1BoldStyle())
                     .foregroundColor(.black)
                     .lineLimit(1)
 
                 if dDayString != "D-DAY" {
                     Text(dDayString)
-                        .font(.Pretendard.b2Bold())
+                        .modifier(Font.Pretendard.b2BoldStyle())
                         .foregroundColor(Color.gray02)
                 } else {
                     Text(dDayString)
-                        .font(.Pretendard.b2Bold())
+                        .modifier(Font.Pretendard.b2BoldStyle())
                         .foregroundColor(Color.blue01)
                 }
 
@@ -311,7 +311,7 @@ struct MyPeopleSection: View {
         VStack(spacing: 8) {
             HStack {
                 Text("내 사람들")
-                    .font(Font.Pretendard.h2Bold())
+                    .modifier(Font.Pretendard.h2BoldStyle())
                     .foregroundStyle(Color.black)
                 Spacer()
                 Button {
@@ -354,7 +354,7 @@ struct MyPeopleSection: View {
                         }
                         Text("가까워 지고 싶은 사람을\n추가해보세요.")
                             .multilineTextAlignment(.center)
-                            .font(Font.Pretendard.b1Medium())
+                            .modifier(Font.Pretendard.b1MediumStyle())
                             .foregroundColor(.gray02)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -560,7 +560,7 @@ struct StarPositionLayout: View {
                             .background(Color.bg01)
                             .clipShape(Circle())
                         Text("사람 추가")
-                            .font(Font.Pretendard.b2Bold())
+                            .modifier(Font.Pretendard.b2BoldStyle())
                             .foregroundColor(.black)
                     }
                 }
@@ -621,11 +621,11 @@ struct PersonCircleView: View {
             }
 
             Text(people.name)
-                .font(Font.Pretendard.b2Bold())
+                .modifier(Font.Pretendard.b2BoldStyle())
                 .foregroundColor(.black)
             HStack(spacing: 4) {
                 Text(formattedDate)
-                    .font(Font.Pretendard.captionMedium())
+                    .modifier(Font.Pretendard.captionMediumStyle())
                     .foregroundColor(Color.gray02)
                 if formattedDate != "챙김 기록이 없어요" {
                     Image("icon_check_blue")

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileDetailView.swift
@@ -162,7 +162,7 @@ struct HistorySection: View {
       
         VStack(alignment: .leading, spacing: 16) {
             Text("챙김 기록")
-                .font(Font.Pretendard.b2Bold())
+                .modifier(Font.Pretendard.b2BoldStyle())
                 .foregroundColor(.black)
             ScrollView {
                 if records.isEmpty {
@@ -171,8 +171,7 @@ struct HistorySection: View {
                         Image("img_100_character_empty")
 //                        Spacer()
                         Text("챙긴 기록이 없어요.\n오늘 챙겨볼까요?")
-                            .font(Font.Pretendard.b2Medium())
-                            .font(Font.Pretendard.b2Medium())
+                            .modifier(Font.Pretendard.b2MediumStyle())
                             .foregroundColor(Color.gray01)
                             .multilineTextAlignment(.center)
                         Spacer()
@@ -199,12 +198,12 @@ struct HistorySection: View {
                                             .frame(width: 40, height: 40)
                                                                            
                                         Text("\(totalRecordCount - index)번째 챙김")
-                                            .font(Font.Pretendard.b2Medium())
+                                            .modifier(Font.Pretendard.b2MediumStyle())
                                             .foregroundColor(.blue01)
                                     }
                                 }
                                 Text(record.createdAt.formattedYYMMDDWithDot())
-                                    .font(Font.Pretendard.b2Medium())
+                                    .modifier(Font.Pretendard.b2MediumStyle())
                                     .foregroundColor(.gray01)
                             }
                             
@@ -256,17 +255,17 @@ private struct ProfileHeader: View {
                 
                 Text(people.name)
                     .frame(height: 22)
-                    .font(Font.Pretendard.h2Bold())
+                    .modifier(Font.Pretendard.h2BoldStyle())
                     .multilineTextAlignment(.center)
                 
                 //MM월dd일 더 가까워졌어요
                 if let latestRecordDate = checkInRecords.sorted(by: { $0.createdAt > $1.createdAt }).first?.createdAt {
                     Text("\(latestRecordDate.formattedYYYYMMDDMoreCloser())")
-                        .font(Font.Pretendard.b2Medium())
+                        .modifier(Font.Pretendard.b2MediumStyle())
                         .foregroundColor(Color.blue01)
                 } else {
                     Text("-")
-                        .font(Font.Pretendard.b2Medium())
+                        .modifier(Font.Pretendard.b2MediumStyle())
                         .foregroundColor(Color.blue01)
                 }
             }
@@ -376,10 +375,10 @@ private struct ActionButton: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: systemImage)
-                .font(Font.Pretendard.h1Bold())
+                .modifier(Font.Pretendard.h1BoldStyle())
                 .foregroundColor(enabled ? .blue01 : .gray02)
             Text(title)
-                .font(Font.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
                 .foregroundColor(enabled ? .black : .gray02)
         }
         .padding()
@@ -417,7 +416,7 @@ private struct TabButton: View {
     var body: some View {
         VStack(spacing: 9) {
             Text(title)
-                .font(Font.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
                 .foregroundColor(isSelected ? .black : .gray02)
             
             Rectangle()
@@ -458,11 +457,11 @@ private struct InfoRow: View {
     var body: some View {
         HStack {
             Text(label)
-                .font(Font.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
                 .foregroundColor(.gray01)
             Spacer()
             Text(value)
-                .font(Font.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
         }
         .padding()
         .frame(minHeight: 54)
@@ -480,14 +479,14 @@ private struct MemoRow: View {
     var body: some View {
         HStack(alignment: .top, spacing: 4) {
             Text(label)
-                .font(Font.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
                 .foregroundColor(.gray01)
                 .frame(width: 60, alignment: .leading)
             
             Spacer()
             
             Text(value == "-" ? initialValue : value)
-                .font(Font.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
                 .foregroundColor(value == "-" ? Color.gray02 : Color.black)
                 .multilineTextAlignment(.trailing)
                 .fixedSize(horizontal: false, vertical: true)
@@ -511,7 +510,7 @@ private struct ConfirmButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(Font.Pretendard.b1Medium())
+                .modifier(Font.Pretendard.b1MediumStyle())
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
@@ -592,3 +591,4 @@ struct ProfileDetailView_Previews: PreviewProvider {
         .previewDisplayName(deviceName)
     }
 }
+

--- a/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileEditView.swift
+++ b/SwypApp2nd/Sources/Views/Home/ProfileDetail/ProfileEditView.swift
@@ -75,14 +75,14 @@ struct NameSection: View {
             HStack(spacing: 0) {
                 Text("이름")
                     .foregroundColor(Color.gray)
-                    .font(Font.Pretendard.b2Medium())
+                    .modifier(Font.Pretendard.b2MediumStyle())
                 Text("*")
                     .foregroundColor(Color.blue01)
-                    .font(Font.Pretendard.b2Medium())
+                    .modifier(Font.Pretendard.b2MediumStyle())
             }
             Spacer()
             TextField("20자 내로 이름을 입력해주세요", text: $name)
-                .font(Font.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
                 .autocorrectionDisabled(true)
                 .textInputAutocapitalization(.never)
                 .padding(16)
@@ -108,7 +108,7 @@ struct RelationshipSection: View {
         HStack(alignment: .center, spacing: 12) {
             Text("관계")
                 .foregroundColor(.gray)
-                .font(.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
             Spacer()
             HStack(spacing: 24) {
                 ForEach(options, id: \.self) { option in
@@ -117,7 +117,7 @@ struct RelationshipSection: View {
                             .foregroundColor(displayLabel(for: relationship) == option ? Color.blue01 : Color.gray03)
                         
                         Text(option)
-                            .font(.Pretendard.b2Medium())
+                            .modifier(Font.Pretendard.b2MediumStyle())
                             .foregroundColor(.black)
                             .lineLimit(nil)
                             .fixedSize(horizontal: false, vertical: true)
@@ -158,7 +158,7 @@ struct FrequencySection: View {
         HStack(alignment: .center, spacing: 12) {
             Text("연락 주기")
                 .foregroundColor(.gray)
-                .font(.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
 
             Spacer()
 
@@ -169,14 +169,14 @@ struct FrequencySection: View {
                     }) {
                         Text(option)
                             .foregroundColor(.black)
-                            .font(Font.Pretendard.b2Medium())
+                            .modifier(Font.Pretendard.b2MediumStyle())
                     }
                 }
             } label: {
                 HStack {
                     Text(frequency?.rawValue ?? "선택")
                         .foregroundColor(.black)
-                        .font(Font.Pretendard.b2Medium())
+                        .modifier(Font.Pretendard.b2MediumStyle())
                     Spacer()
                     Image(systemName: "chevron.down")
                         .foregroundColor(.gray)
@@ -204,7 +204,7 @@ struct BirthdaySection: View {
             HStack(alignment: .center, spacing: 12) {
                 Text("생일")
                     .foregroundColor(.gray)
-                    .font(.Pretendard.b2Medium())
+                    .modifier(Font.Pretendard.b2MediumStyle())
 
                 Spacer()
 
@@ -212,7 +212,7 @@ struct BirthdaySection: View {
                     isPickerVisible.toggle()
                 } label: {
                     Text(birthday != nil ? formattedDate(birthday!) : "선택")
-                        .font(.Pretendard.b2Medium())
+                        .modifier(Font.Pretendard.b2MediumStyle())
                         .foregroundColor(birthday != nil ? .black : .gray02)
                         .padding(16)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -261,7 +261,7 @@ struct AnniversarySection: View {
             // Label
             Text("기념일")
                 .foregroundColor(.gray)
-                .font(.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
 
             // Title Input
             TextField("기념일 이름", text: Binding(
@@ -290,7 +290,7 @@ struct AnniversarySection: View {
             } label: {
                 HStack {
                     Text(anniversary?.Date?.formattedYYYYMMDDWithDot() ?? "날짜 선택")
-                        .font(.Pretendard.b2Medium())
+                        .modifier(Font.Pretendard.b2MediumStyle())
                         .foregroundColor(anniversary?.Date != nil ? .black : .gray02)
 
                     Spacer()
@@ -336,13 +336,13 @@ struct MemoSection: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("메모")
                 .foregroundColor(.gray)
-                .font(.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
 
             ZStack(alignment: .topLeading) {
                 if (memo ?? "").isEmpty {
                     Text("꼭 기억해야 할 내용을 기록해보세요. 예) 날생선 X, 작년에 생일에 키링 선물함 등")
                     .foregroundColor(.gray02)
-                    .font(Font.Pretendard.b1Bold())
+                    .modifier(Font.Pretendard.b1BoldStyle())
                     .padding(16)
                 }
 
@@ -390,7 +390,7 @@ struct WheelDatePicker: View {
         VStack(alignment: .leading) {
             if !title.isEmpty {
                 Text(title)
-                    .font(.headline)
+                    .modifier(Font.Pretendard.b1MediumStyle())
             }
                 
             Button {

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -20,12 +20,12 @@ struct ContactFrequencySettingsView: View {
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     Text("챙김 주기 설정하기")
-                        .font(.Pretendard.b1Bold())
+                        .modifier(Font.Pretendard.b1BoldStyle())
                     
                     Spacer()
                     
                     Text("2 / 2")
-                        .font(.Pretendard.captionBold())
+                        .modifier(Font.Pretendard.captionBoldStyle())
                         .foregroundColor(.gray02)
                 }
                 
@@ -36,11 +36,11 @@ struct ContactFrequencySettingsView: View {
                     .frame(height: 80)
 
                 Text("얼마나 자주\n챙기고 싶으세요?")
-                    .font(.Pretendard.h1Bold())
+                    .modifier(Font.Pretendard.h1BoldStyle())
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
                 Text("사람별로 챙기고 싶은 주기를 설정해주세요.")
-                    .font(.Pretendard.b1Medium())
+                    .modifier(Font.Pretendard.b1MediumStyle())
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
                     .foregroundColor(.gray02)
@@ -58,7 +58,7 @@ struct ContactFrequencySettingsView: View {
                 }) {
                     HStack(spacing: 12) {
                         Text("한번에 설정")
-                            .font(.Pretendard.b1Medium())
+                            .modifier(Font.Pretendard.b1MediumStyle())
                             .foregroundColor(.gray02)
                         ZStack {
                             RoundedRectangle(cornerRadius: 6)
@@ -142,7 +142,7 @@ struct ContactFrequencySettingsView: View {
                     viewModel.toggleUnifiedFrequency(isChecked)
                 } label: {
                     Text("이전")
-                        .font(.body.bold())
+                        .modifier(Font.Pretendard.b1BoldStyle())
                         .frame(maxWidth: .infinity)
                         .frame(height: 52)
                         .background(Color.white)
@@ -172,7 +172,7 @@ struct ContactFrequencySettingsView: View {
                 }
                 label: {
                     Text("완료")
-                        .font(.body.bold())
+                        .modifier(Font.Pretendard.b1BoldStyle())
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .frame(height: 52)
@@ -227,12 +227,12 @@ struct FrequencyRow: View {
             }
             
             Text(person.name)
-                .font(.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
             Spacer()
             Button(action: { if !isUnified { onSelect() } }
             ) {
                 Text(person.frequency?.rawValue ?? "주기 선택")
-                    .font(.Pretendard.b2Medium())
+                    .modifier(Font.Pretendard.b2MediumStyle())
                 Image(systemName: "chevron.down")
             }
             .foregroundStyle(Color.gray01)

--- a/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
@@ -41,11 +41,11 @@ struct RegisterFriendView: View {
                 
                 HStack {
                     Text("챙길 사람 불러오기")
-                        .font(.Pretendard.b1Bold())
+                        .modifier(Font.Pretendard.b1BoldStyle())
                         .foregroundColor(.black)
                     Spacer()
                     Text("1 / 2")
-                        .font(.Pretendard.captionBold())
+                        .modifier(Font.Pretendard.captionBoldStyle())
                         .foregroundColor(.gray02)
                 }
                 
@@ -56,10 +56,10 @@ struct RegisterFriendView: View {
                     .frame(height: 80)
 
                 Text("가까워지고 싶은 사람\n10명까지 선택해주세요")
-                    .font(.Pretendard.h1Bold())
+                    .modifier(Font.Pretendard.h1BoldStyle())
 
                 Text("먼저, 더 가까워지고 싶은\n소중한 사람만 선택해주세요.")
-                    .font(.Pretendard.b1Medium())
+                    .modifier(Font.Pretendard.b1MediumStyle())
                     .foregroundColor(.gray02)
             }
             .padding(.horizontal, 20)
@@ -129,7 +129,7 @@ struct RegisterFriendView: View {
             HStack(spacing: 12) {
                 Button(action: skip) {
                     Text("나중에 하기")
-                        .font(.Pretendard.b1Bold())
+                        .modifier(Font.Pretendard.b1BoldStyle())
                         .frame(maxWidth: .infinity)
                         .foregroundColor(.black)
                         .frame(height: 52)
@@ -142,7 +142,7 @@ struct RegisterFriendView: View {
 
                 Button(action: proceed) {
                     Text("다음")
-                        .font(.Pretendard.b1Bold())
+                        .modifier(Font.Pretendard.b1BoldStyle())
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .frame(height: 52)
@@ -198,14 +198,14 @@ struct CardButton: View {
                     .cornerRadius(8)
 
                 Text(title)
-                    .font(.Pretendard.b2Medium())
+                    .modifier(Font.Pretendard.b2MediumStyle())
                     .foregroundColor(.black)
 
                 Spacer()
 
                 if hasContacts {
                     Text("다시 선택")
-                        .font(.Pretendard.b2Medium())
+                        .modifier(Font.Pretendard.b2MediumStyle())
                         .foregroundColor(.blue01)
                 } else {
                     Image(systemName: "chevron.right")
@@ -241,7 +241,7 @@ struct ContactRow: View {
                 .frame(width: 24, height: 24)
 
             Text(contact.name)
-                .font(.Pretendard.b2Medium())
+                .modifier(Font.Pretendard.b2MediumStyle())
                 .foregroundColor(.black)
 
             Spacer()

--- a/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/Terms/TermsView.swift
@@ -20,7 +20,7 @@ public struct TermsView: View {
         VStack(alignment: .leading) {
 
             Text("서비스 약관 동의")
-                .font(Font.Pretendard.h2Bold())
+                .modifier(Font.Pretendard.h2BoldStyle())
                 .padding(.leading, 24)
                 .padding(.top, 44)
 
@@ -116,7 +116,7 @@ public struct TermsView: View {
             }) {
                 Text("가입")
                     .foregroundColor(.white)
-                    .font(Font.Pretendard.b1Bold())
+                    .modifier(Font.Pretendard.b1BoldStyle())
                     .frame(maxWidth: .infinity)
                     .frame(height: 56)
                     .background(viewModel.canProceed ? Color.blue01 : Color.gray02)
@@ -137,7 +137,7 @@ public struct TermsView: View {
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         Text(agreement.title)
-                            .font(Font.Pretendard.b1Medium())
+                            .modifier(Font.Pretendard.b1MediumStyle())
                             .foregroundStyle(Color.black)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
@@ -222,7 +222,7 @@ public struct AgreementRow: View {
             }
             
             Text(title)
-                .font(isBold ? .Pretendard.b1Bold() : .Pretendard.b1Medium())
+                .modifier(isBold ? Font.Pretendard.b1BoldStyle() : Font.Pretendard.b1MediumStyle())
                 .foregroundStyle(Color.black)
             
             Spacer()

--- a/SwypApp2nd/Sources/Views/My/MyProfileView.swift
+++ b/SwypApp2nd/Sources/Views/My/MyProfileView.swift
@@ -100,7 +100,7 @@ struct UserProfileSectionView: View {
                     .frame(width: 80, height: 80)
             }
             Text(name)
-                .font(Font.Pretendard.b1Bold())
+                .modifier(Font.Pretendard.b1BoldStyle())
         }
         .padding(.top, 20)
     }
@@ -113,13 +113,13 @@ struct AccountSettingSectionView: View {
         VStack(spacing: 1) {
             VStack(alignment: .leading, spacing: 24) {
                 Text("일반")
-                    .font(Font.Pretendard.b1Bold())
+                    .modifier(Font.Pretendard.b1BoldStyle())
                     .fontWeight(.bold)
                     .padding(.top, 42)
 
                 HStack {
                     Text("연결계정")
-                        .font(Font.Pretendard.b1Medium())
+                        .modifier(Font.Pretendard.b1MediumStyle())
                         .foregroundColor(.black)
                     Spacer()
                     let (loginName, imageName): (String, String) = {
@@ -144,7 +144,7 @@ struct NotificationSettingsView: View {
     var body: some View {
         HStack {
             Text("알림설정")
-                .font(Font.Pretendard.b1Medium())
+                .modifier(Font.Pretendard.b1MediumStyle())
             Spacer()
             Toggle("", isOn: $viewModel.isNotificationOn)
                 .tint(Color.blue02)
@@ -198,7 +198,7 @@ struct SimpleTermsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("서비스 정보")
-                .font(Font.Pretendard.b1Bold())
+                .modifier(Font.Pretendard.b1BoldStyle())
                 .fontWeight(.bold)
                 .padding(.top, 42)
                 .padding(.bottom, 14)
@@ -209,7 +209,7 @@ struct SimpleTermsView: View {
                 } label: {
                     HStack {
                         Text(term.title)
-                            .font(.body)
+                            .modifier(Font.Pretendard.b2MediumStyle())
                             .foregroundColor(.black)
                         Spacer()
                         Image(systemName: "chevron.right")
@@ -294,10 +294,10 @@ struct WithdrawalButtonView: View {
                 AnalyticsManager.shared.withdrawButtonLogAnalytics()
             }) {
                 Text("탈퇴하기")
-                    .font(Font.Pretendard.b2Medium())
+                    .modifier(Font.Pretendard.b2MediumStyle())
                     .underline()
                     .lineSpacing(4)
-                    .kerning(-0.25)  // TODO
+                    .kerning(-0.25)
                     .foregroundColor(Color.gray01)
                     .padding(.bottom, 20)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
+++ b/SwypApp2nd/Sources/Views/My/WithdrawalView.swift
@@ -75,12 +75,11 @@ struct WithdrawalHeaderView: View {
         }
         
         Text("\(name)님, \n떠나는 이유를 알려주시면 \n큰 도움이 될 거예요.")
-            .font(Font.Pretendard.h1Medium(size: 24))
-            .lineSpacing(8)
+            .modifier(Font.Pretendard.h1MediumStyle())
             .padding(.top, 42)
-        
+
         Text("소중한 의견을 받아 \n더 나은 서비스를 만들어갈게요.")
-            .font(Font.Pretendard.b1Medium())
+            .modifier(Font.Pretendard.b1MediumStyle())
             .foregroundColor(.gray)
             .padding(.bottom, 42)
     }
@@ -137,7 +136,7 @@ struct CustomReasonInputView: View {
 
                 if customReason.isEmpty {
                     Text("편하게 의견을 남겨주세요.")
-                        .font(Font.Pretendard.b1Medium())
+                        .modifier(Font.Pretendard.b1MediumStyle())
                         .foregroundColor(Color.gray02)
                         .padding(.leading, 16)
                         .padding(.top, 20)
@@ -190,7 +189,7 @@ struct WithdrawalActionButtonsView: View {
                 Text("그만두기")
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .font(Font.Pretendard.b1Bold())
+                    .modifier(Font.Pretendard.b1BoldStyle())
                     .foregroundColor(.white)
                     .background(Color.blue01)
                     .cornerRadius(12)
@@ -198,7 +197,7 @@ struct WithdrawalActionButtonsView: View {
 
             Button(action: {showConfirmAlert = true}) {
                 Text("탈퇴하기")
-                    .font(Font.Pretendard.b1Bold())
+                    .modifier(Font.Pretendard.b1BoldStyle())
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.clear)


### PR DESCRIPTION
## ✨ 변경 사항 요약
- Pretendard 폰트 스타일에 LineHeight, LetterSpacing(자간) 적용
- 주요 텍스트 스타일을 .modifier(Font.Pretendard.XXXStyle()) 방식으로 일괄 전환

## 📄 작업 내용 상세 설명
- PretendardTextStyle ViewModifier를 추가하여 폰트 lineHeight, letterSpacing을 일관 적용
- 기존 `.font(Font.Pretendard.XXX())` 사용 부분을 `.modifier(Font.Pretendard.XXXStyle())`로 변경
- 디자인 가이드에 맞는 타이포그래피 스펙(폰트, 줄간격, 자간) 반영
- 기존 Font 반환 메서드는 호환성 유지를 위해 그대로 두고, Modifier 스타일을 병행 지원

### 🎯 작업 목적
- 디자인 시스템의 타이포그래피 스펙을 코드에 일관되게 반영하여 UI 품질 및 유지보수성을 향상

### 🛠️ 주요 변경 사항
- PretendardTextStyle ViewModifier 추가: `Font+Extension.swift`
- 주요 View에서 `.font(Font.Pretendard.XXX())` → `.modifier(Font.Pretendard.XXXStyle())`로 변경
- [기타: 텍스트 스타일 일관성 강화, 디자인 가이드 준수]

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [x] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- `.modifier(Font.Pretendard.XXXStyle())` 사용 시 Text끼리 `+` 연산 불가 → HStack 등으로 분리 필요 (modifire를 사용하면 someView로 타입 변경됨)
- 기존 Font 반환 메서드도 남아있으므로 점진적 전환 가능

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #23 