### PR TITLE
[Feat, Fix] 연락처 이름 처리 시 공백 추가, 연락처 개수 제한 Alert 이슈 해결

### DIFF
--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -8,6 +8,23 @@ import KakaoSDKAuth
 import Combine
 import Contacts
 
+enum RegisterFriendsAlert: Identifiable {
+    case limitExceeded(total: Int) // 전체 10명 초과
+    case phoneSelectionExceeded// 선택 가능한 슬롯 초과
+    case permissionDenied// 연락처 권한 OFF
+    
+    var id: String {
+        switch self {
+        case .limitExceeded:
+            return "limitExceeded"
+        case .phoneSelectionExceeded: 
+            return "phoneSelectionExceeded"
+        case .permissionDenied:       
+            return "permissionDenied"
+        }
+    }
+}
+
 struct AlertItem: Identifiable {
     let id = UUID()
     let message: String
@@ -15,18 +32,12 @@ struct AlertItem: Identifiable {
 
 class RegisterFriendsViewModel: ObservableObject {
     @Published var selectedContacts: [Friend] = []
-    @Published var alertItem: AlertItem? = nil // 10명 넘을시 alert
+    @Published var activeAlert: RegisterFriendsAlert? = nil
     
     private let contactStore = CNContactStore()
     
     var canProceed: Bool {
         !selectedContacts.isEmpty
-    }
-
-    func addContact(_ contact: Friend) {
-        guard selectedContacts.count < 10 else { return }
-        guard !selectedContacts.contains(contact) else { return }
-        selectedContacts.append(contact)
     }
 
     func removeContact(_ contact: Friend) {
@@ -35,10 +46,6 @@ class RegisterFriendsViewModel: ObservableObject {
     
     var phoneContacts: [Friend] {
         selectedContacts.filter { $0.source == .phone }
-    }
-
-    var kakaoContacts: [Friend] {
-        selectedContacts.filter { $0.source == .kakao }
     }
     
     // MARK: - 애플 연락처 연동
@@ -110,158 +117,39 @@ class RegisterFriendsViewModel: ObservableObject {
         }
         print("🟢 [RegisterFriendsViewModel]\(String(describing: converted.first?.name))의 id: \(String(describing: converted.first?.id))")
         
-        DispatchQueue.main.async {
-            let existingFriends = UserSession.shared.user?.friends ?? []
-            let existingIds = Set(existingFriends.map { $0.id })
-            
-            let totalCount = self.selectedContacts.count + existingFriends.count
-            if totalCount > 10 {
-                self.alertItem = AlertItem(message: "최대 10명까지만 등록할 수 있어요.")
-                return
-            }
+        // 기존 등록된 친구 목록
+        let existingFriends = UserSession.shared.user?.friends ?? []
+        let existingIds = Set(existingFriends.map { $0.id })
 
-            let newContacts = converted.filter { !existingIds.contains($0.id) }
-            let remainingPhone = max(0, 10 - self.phoneContacts.count)
-            let limited = Array(newContacts.prefix(remainingPhone))
-            
-            if newContacts.count > remainingPhone {
-                self.alertItem = AlertItem(message: "연락처는 최대 10명까지만 선택할 수 있어요.")
-                return
-            }
-            
-            let existingKakao = self.selectedContacts.filter { $0.source == .kakao }
-            self.selectedContacts = Array(Set(existingKakao + limited))
+        // 이미 선택한 전화 연락처
+        let existingPhone = self.phoneContacts
+        // 새로 추가될 연락처: 기존 등록된 친구들과 겹치지 않는 것만
+        let newContacts = converted.filter { !existingIds.contains($0.id) }
 
-            print("🟢 등록된 연락처 수: \(self.phoneContacts.count) / 5")
-        }
-        print("🟢 [RegisterFriendsViewModel] 연락처 가져옴: \(self.selectedContacts)")
-    }
-    
-    // MARK: - kakao 연락처 연동
-    func fetchContactsFromKakao() {
-        // MARK: - Test
-        // Kakao 토큰이 없으면 로그인 연동 먼저 진행
-        
-        // 1. 카카오 로그인 (애플 로그인시에 카카오톡 로그인만 해서 친구 데이터만 가져오기)
-        // 2. 토큰 관리..? -> 애플로그인이 진행됐으니 토큰은 필요없나,, 카카오 서버 토큰은 필요할듯
-        // 3. 카카오 친구목록 호출
-        print("🟡 [RegisterFriendsViewModel] fetchContactsFromKakao 호출됨")
-        
-        if let path = Bundle.main.path(forResource: "KakaoSDKFriendResources", ofType: "bundle") {
-            print("KakaoSDKFriendResources.bundle 포함됨: \(path)")
-        } else {
-            print("KakaoSDKFriendResources.bundle 미포함")
-        }
-        
-        if TokenManager.shared.get(for: .kakao) != nil {
-            print("🟢 [RegisterFriendsViewModel] 기존 Kakao 토큰 있음 → 친구목록 요청")
-            self.requestKakaoFriends()
-        } else {
-            print("🟡 [RegisterFriendsViewModel] Kakao 토큰 없음 → 로그인 시도")
-            SnsAuthService.shared.loginWithKakao { oauthToken in
-                guard let token = oauthToken else {
-                    print("🔴 [RegisterFriendsViewModel] 카카오 로그인 실패")
-                    return
-                }
-
-                TokenManager.shared.save(token: token.accessToken, for: .kakao)
-                TokenManager.shared
-                    .save(token: token.refreshToken, for: .kakao, isRefresh: true)
-
-                print("🟢 [RegisterFriendsViewModel] 카카오 로그인 성공 → 친구목록 요청")
-                self.requestKakaoFriends()
-            }
-        }
-    }
-    
-    func requestKakaoFriends() {
-        print("requestKakaoFriends 호출됨")
-        // TODO: - Kakao비즈니스, 권한 신청 해야함
-        // Kakao 친구 API 호출
-        let openPickerFriendRequestParams = OpenPickerFriendRequestParams(
-            title: "멀티 피커", // 피커 이름
-            viewAppearance: .auto, // 피커 화면 모드
-            orientation: .auto, // 피커 화면 방향
-            enableSearch: false, // 검색 기능 사용 여부
-            enableIndex: false, // 인덱스뷰 사용 여부
-            showMyProfile: false, // 내 프로필 표시
-            showFavorite: true, // 즐겨찾기 친구 표시 여부
-            showPickedFriend: true, // 선택한 친구 표시 여부, 멀티 피커에만 사용 가능
-            maxPickableCount: 5, // 선택 가능한 최대 대상 수
-            minPickableCount: 1 // 선택 가능한 최소 대상 수
-        )
-        PickerApi.shared.selectFriendsPopup(params: openPickerFriendRequestParams) {
- selectedUsers,
- error in
-            
-            // TODO: - 탈퇴후 테스트 필요
-            if let error = error as? SdkError,
-               case .ApiFailed(_, _) = error,
-               error.localizedDescription.contains("scope") {
-                print("🔴 친구목록 권한 미동의 → scope 재요청")
-
-                UserApi.shared
-                    .loginWithKakaoAccount(scopes: ["friends"]) { _, error in
-                        if let error = error {
-                            print("🔴 friends scope 동의 실패: \(error)")
-                        } else {
-                            print("🟢 friends scope 동의 성공 → 친구목록 재요청")
-                            self.requestKakaoFriends()
-                        }
-                    }
-                return
-            }
-
-            if let error = error {
-                print("🔴 친구 피커 오류: \(error)")
-                return
-            }
-
-            guard let selectedUsers = selectedUsers?.users else {
-                print("🟡 선택된 친구 없음")
-                return
-            }
-
-            print("✅ 친구 선택 성공: \(selectedUsers)")
-                
-            // TODO: - 썸네일 이미지 URL → Signed URL 적용
-            let kakaoContacts: [Friend] = selectedUsers.compactMap {
-                let id = UUID()
-                return Friend(
-                    id: id,
-                    name: $0.profileNickname ?? "이름 없음",
-                    imageURL: $0.profileThumbnailImage?.absoluteString,
-                    source: .kakao,
-                    frequency: CheckInFrequency.none,
-                    relationship: "",  //TODO : 이렇게가 맞나
-                    fileName: "\(id.uuidString).jpg"
-                )
-            }
+        // 전체 등록될 수 있는 수 계산: 기존 등록된 친구 + 기존 전화 연락처 + 새로 선택한 연락처
+        let potentialTotal = existingFriends.count + existingPhone.count + newContacts.count
+        if potentialTotal > 10 {
             DispatchQueue.main.async {
-                let existingFriends = UserSession.shared.user?.friends ?? []
-                let existingIds = Set(existingFriends.map { $0.id })
-
-                let totalCount = self.selectedContacts.count + existingFriends.count
-                if totalCount > 10 {
-                    self.alertItem = AlertItem(message: "최대 10명까지만 등록할 수 있어요.")
-                    return
-                }
-                
-                let newKakaoContacts = kakaoContacts.filter {
-                    !existingIds.contains($0.id)
-                }
-
-                let remainingKakao = max(0, 5 - self.kakaoContacts.count)
-                let limited = Array(newKakaoContacts.prefix(remainingKakao))
-
-                let existingPhone = self.selectedContacts.filter {
-                    $0.source == .phone
-                }
-                self.selectedContacts = Array(Set(existingPhone + limited))
-
-                print("🟢 등록된 카카오 친구 수: \(self.kakaoContacts.count) / 5")
+                self.activeAlert = .limitExceeded(total: potentialTotal)
             }
-            
+            print("🟢 [RegisterFriendsViewModel] 최대 10명까지만 등록할 수 있어요. alert 발생")
+            return
         }
+
+        // 남은 전화 연락처 선택 가능 수
+        let remainingPhone = max(0, 10 - existingPhone.count)
+        // 새로 선택한 연락처 중 남은 수만큼만 사용
+        if newContacts.count > remainingPhone {
+            DispatchQueue.main.async {
+                self.activeAlert = .phoneSelectionExceeded
+            }
+            print("🟢 [RegisterFriendsViewModel] 연락처는 최대 10명까지만 선택할 수 있어요. alert 발생")
+            return
+        }
+        let limited = Array(newContacts.prefix(remainingPhone))
+
+        // 기존 전화 연락처와 새로 선택한 연락처를 합쳐 중복을 제거한 후 적용
+        let updatedPhone = existingPhone + limited
+        self.selectedContacts = Array(Set(updatedPhone))
     }
 }

--- a/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/RegisterFriends/RegisterFriendsViewModel.swift
@@ -17,9 +17,9 @@ enum RegisterFriendsAlert: Identifiable {
         switch self {
         case .limitExceeded:
             return "limitExceeded"
-        case .phoneSelectionExceeded: 
+        case .phoneSelectionExceeded:
             return "phoneSelectionExceeded"
-        case .permissionDenied:       
+        case .permissionDenied:
             return "permissionDenied"
         }
     }
@@ -75,7 +75,7 @@ class RegisterFriendsViewModel: ObservableObject {
     
     func handleSelectedContacts(_ contacts: [CNContact]) {
         let converted: [Friend] = contacts.compactMap {
-            let name = $0.familyName + $0.givenName
+            let name = $0.familyName + " " + $0.givenName
             let image = $0.thumbnailImageData.flatMap { UIImage(data: $0) }
             let birthDay = $0.birthday?.date
             let anniversaryDateComponents = $0.dates.first?.value as? DateComponents

--- a/SwypApp2nd/Sources/ViewModels/ViewModels.swift
+++ b/SwypApp2nd/Sources/ViewModels/ViewModels.swift
@@ -1,1 +1,0 @@
-// Empty.swift

--- a/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/ContactFrequencySettings/ContactFrequencySettingsView.swift
@@ -6,6 +6,7 @@ struct ContactFrequencySettingsView: View {
 
     @State private var selectedPerson: Friend?
     @State private var showFrequencyPicker: Bool = false
+    @State private var pickerSelectedFrequency: CheckInFrequency? = nil
     
     let back: () -> Void
     let complete: ([Friend]) -> Void
@@ -51,10 +52,13 @@ struct ContactFrequencySettingsView: View {
             // 한 번에 설정
             HStack {
                 Spacer()
-                
                 Button(action: {
-                    viewModel.toggleUnifiedFrequency(!viewModel.isUnified)
-                    self.isChecked.toggle()
+                    let newValue = !viewModel.isUnified
+                    viewModel.toggleUnifiedFrequency(newValue)
+                    isChecked = newValue
+                    if newValue {
+                        pickerSelectedFrequency = viewModel.unifiedFrequency
+                    }
                 }) {
                     HStack(spacing: 12) {
                         Text("한번에 설정")
@@ -71,23 +75,25 @@ struct ContactFrequencySettingsView: View {
                                     isChecked ? Color.blue01 : Color.gray03
                                 )
                                 .cornerRadius(6)
-                        
                             Image("icon_check_white")
                                 .resizable()
                                 .scaledToFit()
                                 .frame(width: 14, height: 14)
-                            
                         }
                     }
-                    
                 }
-//                .buttonStyle(.plain)
                 .padding(.horizontal, 20)
             }
             
             // 공통 주기 설정 드롭다운
             if viewModel.isUnified {
                 Button(action: {
+                    if viewModel.unifiedFrequency == nil {
+                        viewModel.applyUnifiedFrequency(.weekly)
+                        pickerSelectedFrequency = .weekly
+                    } else {
+                        pickerSelectedFrequency = viewModel.unifiedFrequency
+                    }
                     showFrequencyPicker = true
                 }) {
                     HStack {
@@ -98,9 +104,7 @@ struct ContactFrequencySettingsView: View {
                         .foregroundColor(
                             viewModel.unifiedFrequency == nil ? .gray02 : .black
                         )
-
                         Spacer()
-
                         Image(systemName: "chevron.down")
                             .foregroundColor(.gray02)
                     }
@@ -126,6 +130,7 @@ struct ContactFrequencySettingsView: View {
                             isUnified: viewModel.isUnified
                         ) {
                             selectedPerson = person
+                            pickerSelectedFrequency = person.frequency
                             showFrequencyPicker = true
                             AnalyticsManager.shared.setCareFrequencyLogAnalytics()
                         }
@@ -139,7 +144,7 @@ struct ContactFrequencySettingsView: View {
                 Button{
                     back()
                     isChecked = false
-                    viewModel.toggleUnifiedFrequency(isChecked)
+                    viewModel.toggleUnifiedFrequency(false)
                 } label: {
                     Text("이전")
                         .modifier(Font.Pretendard.b1BoldStyle())
@@ -157,15 +162,14 @@ struct ContactFrequencySettingsView: View {
                 }
 
                 Button{
-                    // 카카오는 이미지 저장 후 BackEnd 서버에 전송 (스펙 아웃)
-//                    viewModel.downloadKakaoImageData { friendsWithImages in
-//                    }
-                    
                     DispatchQueue.main.async {
                         viewModel.uploadAllFriendsToServer(viewModel.people) {
                             UserSession.shared.user?.friends = viewModel.people
                             AnalyticsManager.shared.setProfileCountBucket(viewModel.people.count)
                             AnalyticsManager.shared.completeButtonLogAnalytics()
+                            self.isChecked = false // 완료 시 체크박스 비활성화
+                            self.showFrequencyPicker = false
+                            viewModel.toggleUnifiedFrequency(false) // ViewModel 상태도 비활성화
                             complete(viewModel.people)
                         }
                     }
@@ -186,9 +190,11 @@ struct ContactFrequencySettingsView: View {
             .padding(.horizontal, 24)
             .padding(.bottom, 20)
         }
-        .sheet(isPresented: $showFrequencyPicker) {
+        .sheet(isPresented: $showFrequencyPicker, onDismiss: {
+            pickerSelectedFrequency = nil
+        }) {
             FrequencyPickerView(
-                selected: viewModel.isUnified ? viewModel.unifiedFrequency : selectedPerson?.frequency,
+                selected: pickerSelectedFrequency,
                 onSelect: { freq in
                     if viewModel.isUnified {
                         viewModel.applyUnifiedFrequency(freq)
@@ -203,6 +209,7 @@ struct ContactFrequencySettingsView: View {
             .presentationCornerRadius(20)
         }
         .onAppear {
+            isChecked = viewModel.isUnified
             AnalyticsManager.shared.trackContactFrequencySettingsViewLogAnalytics()
         }
     }
@@ -254,34 +261,26 @@ struct FrequencyPickerView: View {
     let onSelect: (CheckInFrequency) -> Void
 
     var body: some View {
-        
         VStack(alignment: .leading) {
-
             Text("주기 설정")
                 .font(.headline)
                 .padding(.top, 16)
                 .padding(.leading, 16)
-            
             if let selected = tempSelected {
                 let today = Date()
                 let nextDate = today.nextCheckInDate(for: selected)
                 let nextDateDayOfTheWeek = today.nextCheckInDateDayOfTheWeek(for: selected)
-                
                 HStack {
                     Text("\(selected.rawValue) ")
                         .font(.body)
                         .foregroundColor(.gray02)
-
                     Text(nextDateDayOfTheWeek)
                         .font(.body)
                         .foregroundColor(.blue01)
-
                     Spacer()
-                    
                     Divider()
                         .foregroundColor(.gray02)
                         .frame(height: 20)
-                    
                     Text("다음 주기: \(nextDate)")
                         .font(.caption)
                         .foregroundColor(.gray02)
@@ -292,8 +291,6 @@ struct FrequencyPickerView: View {
                 .padding(.horizontal)
                 .padding(.top, 8)
             }
-            
-     
             VStack(spacing: 0) {
                 ForEach(CheckInFrequency.allCases.dropFirst()) { frequency in
                     Button(action: {
@@ -318,8 +315,6 @@ struct FrequencyPickerView: View {
             }
             .listStyle(.inset)
             .background(Color.white)
-            
-            // 하단 버튼
             HStack(spacing: 12) {
                 Button(action: {
                     dismiss()
@@ -338,12 +333,12 @@ struct FrequencyPickerView: View {
                                 )
                         )
                 }
-
                 Button(action: {
                     if let selected = tempSelected {
                         onSelect(selected)
+                    } else if let selected = selected {
+                        onSelect(selected)
                     }
-                    dismiss()
                 }) {
                     Text("완료")
                         .font(.body.bold())
@@ -358,6 +353,9 @@ struct FrequencyPickerView: View {
         }
         .background(Color.white)
         .cornerRadius(20)
+        .onAppear {
+            tempSelected = selected
+        }
     }
 }
 

--- a/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
+++ b/SwypApp2nd/Sources/Views/Login/RegisterFriends/RegisterFriendsView.swift
@@ -2,9 +2,7 @@ import SwiftUI
 
 struct RegisterFriendView: View {
     @ObservedObject var viewModel: RegisterFriendsViewModel
-    
     @State private var showContactPicker = false
-    @State private var showPermissionAlert = false
 
     let proceed: () -> Void
     let skip: () -> Void
@@ -13,14 +11,6 @@ struct RegisterFriendView: View {
         VStack(spacing: 12) {
             if !viewModel.phoneContacts.isEmpty {
                 ForEach(viewModel.phoneContacts) { contact in
-                    ContactRow(contact: contact) {
-                        viewModel.removeContact(contact)
-                    }
-                }
-            }
-
-            if !viewModel.kakaoContacts.isEmpty {
-                ForEach(viewModel.kakaoContacts) { contact in
                     ContactRow(contact: contact) {
                         viewModel.removeContact(contact)
                     }
@@ -78,7 +68,7 @@ struct RegisterFriendView: View {
                                     if granted {
                                         showContactPicker = true
                                     } else {
-                                        showPermissionAlert = true
+                                        viewModel.activeAlert = .permissionDenied
                                     }
                                 }
                                 AnalyticsManager.shared.contactImportLogAnalytics()
@@ -100,26 +90,6 @@ struct RegisterFriendView: View {
                         }
                     }
                     
-                    // 카카오톡 스펙 아웃
-//                    VStack(spacing: 12) {
-//                        CardButton(
-//                            icon: Image("img_32_kakao_square"),
-//                            title: "카카오톡에서 불러오기 (최대 5명)",
-//                            hasContacts: !viewModel.kakaoContacts.isEmpty,
-//                            action: {
-//                                viewModel.fetchContactsFromKakao()
-//                            }
-//                        )
-//                        
-//                        if !viewModel.kakaoContacts.isEmpty {
-//                            ForEach(viewModel.kakaoContacts) { contact in
-//                                ContactRow(contact: contact) {
-//                                    viewModel.removeContact(contact)
-//                                }
-//                                
-//                            }
-//                        }
-//                    }
                 }
                 .padding(.horizontal, 24)
             }
@@ -154,26 +124,32 @@ struct RegisterFriendView: View {
             .padding(.horizontal, 24)
             .padding(.bottom, 20)
         }
-        .alert(item: $viewModel.alertItem) { item in
-            Alert(
-                title: Text("⚠️ 제한 안내"),
-                message: Text(item.message),
-                dismissButton: .default(Text("확인"))
-            )
-        }
-        .alert(isPresented: $showPermissionAlert) {
-            Alert(
-                title: Text("연락처 권한이 꺼져 있어요"),
-                message: Text("소중한 사람을 불러오기 위해\n설정에서 연락처 접근을 켜주세요."),
-                primaryButton: .default(Text("설정으로 이동")) {
-                    if let url = URL(
-                        string: UIApplication.openSettingsURLString
-                    ) {
-                        UIApplication.shared.open(url)
-                    }
-                },
-                secondaryButton: .cancel(Text("취소"))
-            )
+        .alert(item: $viewModel.activeAlert) { alert in
+            switch alert {
+            case .limitExceeded(let total):
+                return Alert(
+                    title: Text("⚠️ 제한 안내"),
+                    message: Text("최대 10명까지만 등록할 수 있어요.\n(현재 \(total)명)"),
+                    dismissButton: .default(Text("확인"))
+                )
+            case .phoneSelectionExceeded:
+                return Alert(
+                    title: Text("⚠️ 제한 안내"),
+                    message: Text("연락처는 최대 10명까지만 선택할 수 있어요."),
+                    dismissButton: .default(Text("확인"))
+                )
+            case .permissionDenied:
+                return Alert(
+                    title: Text("연락처 권한이 꺼져 있어요"),
+                    message: Text("소중한 사람을 불러오기 위해\n설정에서 연락처 접근을 켜주세요."),
+                    primaryButton: .default(Text("설정으로 이동")) {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    },
+                    secondaryButton: .cancel(Text("취소"))
+                )
+            }
         }
         .onAppear {
             AnalyticsManager.shared.trackRegisterFriendsViewLogAnalytics()


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 연락처 이름 처리 시 공백 추가
- RegisterFriendsViewModel 및 RegisterFriendView 알림 처리 개선 및 연락처 선택 제한 로직 추가
- ContactFrequencySettingsView에서 주기 선택 기능 및 상태 관리 개선

## 📄 작업 내용 상세 설명
- 연락처 이름이 여러 단어일 때 공백이 올바르게 표시되도록 처리
- 연락처 선택 시 최대 10명까지로 제한하는 로직 추가
- 연락처 권한 거부 시 알림(Alert) 처리 UX 개선
- ContactFrequencySettingsView에서 주기 선택 기능 개선 및 관련 상태 관리 로직 추가

### 🎯 작업 목적
- 연락처 관련 UX를 개선하고, 사용자의 실수 방지 및 명확한 안내 제공
- 주기 설정 화면의 사용성 및 상태 관리를 강화

### 🛠️ 주요 변경 사항
- RegisterFriendsViewModel, RegisterFriendView, ContactFrequencySettingsView 등 주요 View 및 ViewModel 로직 개선
- 연락처 이름 처리 방식 변경
- 연락처 선택 제한 및 알림 처리 추가

### 📸 스크린샷 (필요시 추가)
<img width="300" alt="Simulator Screenshot - iPhone 13 mini - 2025-07-29 at 19 49 23" src="https://github.com/user-attachments/assets/707ed6d1-c95b-47cd-81b7-97083f31b39b" />
<img width="300" alt="Simulator Screenshot - iPhone 13 mini - 2025-07-29 at 19 49 57" src="https://github.com/user-attachments/assets/a43c0405-5995-42e9-9525-afaed55b8a35" />


### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 연락처 권한 관련 Alert가 정상적으로 동작하는지 확인 필요
- 연락처 선택 제한(10명)이 올바르게 적용되는지 테스트 필요

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈 번호: #111 
